### PR TITLE
CI Update to Download Test Data Only Once

### DIFF
--- a/tests/test_mnist.py
+++ b/tests/test_mnist.py
@@ -90,24 +90,27 @@ def process_data(num_clients):
 
 
 # Let's download the data first if data does not exist.
-def test_data_validation():    
-    currentpath = os.getcwd()
-    datafolderpath = os.path.join(currentpath, "_data")
-    existsflag = False
-    if(os.path.exists(datafolderpath) and os.path.isdir(datafolderpath)):
-        mnistfolderpath = os.path.join(datafolderpath, "MNIST")
-        if(os.path.exists(mnistfolderpath) and os.path.isdir(mnistfolderpath)):
-            existsflag = True
+currentpath = os.getcwd()
+datafolderpath = os.path.join(currentpath, "_data")
+existsflag = False
+if(os.path.exists(datafolderpath) and os.path.isdir(datafolderpath)):
+    mnistfolderpath = os.path.join(datafolderpath, "MNIST")
+    if(os.path.exists(mnistfolderpath) and os.path.isdir(mnistfolderpath)):
+        existsflag = True
 
-    if(not existsflag):
-        comm = MPI.COMM_WORLD
-        comm_size = comm.Get_size()
-        if comm_size > 1:
-            comm_rank = comm.Get_rank()
-            if comm_rank == 0:
-                torchvision.datasets.MNIST("./_data", download=True, train=False, transform=ToTensor())
-        else:
+if(not existsflag):
+    comm = MPI.COMM_WORLD
+    comm_size = comm.Get_size()
+    if comm_size > 1:
+        comm_rank = comm.Get_rank()
+        if comm_rank == 0:
+            print("Download by rank0")            
             torchvision.datasets.MNIST("./_data", download=True, train=False, transform=ToTensor())
+        comm.Barrier()
+    else:
+        print("Download by serial")
+        torchvision.datasets.MNIST("./_data", download=True, train=False, transform=ToTensor())
+    
 
 
 def test_mnist_fedavg():

--- a/tests/test_mnist.py
+++ b/tests/test_mnist.py
@@ -12,6 +12,9 @@ from appfl.misc.data import *
 import appfl.run_mpi as rm
 import appfl.run_serial as rs
 
+from mpi4py import MPI
+import os
+
 
 class CNN(nn.Module):
     def __init__(self, num_channel, num_classes, num_pixel):
@@ -86,8 +89,25 @@ def process_data(num_clients):
     return train_datasets, test_dataset
 
 
-# Let's download the data first.
-torchvision.datasets.MNIST("./_data", download=True, train=False, transform=ToTensor())
+# Let's download the data first if data does not exist.
+def test_data_validation():    
+    currentpath = os.getcwd()
+    datafolderpath = os.path.join(currentpath, "_data")
+    existsflag = False
+    if(os.path.exists(datafolderpath) and os.path.isdir(datafolderpath)):
+        mnistfolderpath = os.path.join(datafolderpath, "MNIST")
+        if(os.path.exists(mnistfolderpath) and os.path.isdir(mnistfolderpath)):
+            existsflag = True
+
+    if(not existsflag):
+        comm = MPI.COMM_WORLD
+        comm_size = comm.Get_size()
+        if comm_size > 1:
+            comm_rank = comm.Get_rank()
+            if comm_rank == 0:
+                torchvision.datasets.MNIST("./_data", download=True, train=False, transform=ToTensor())
+        else:
+            torchvision.datasets.MNIST("./_data", download=True, train=False, transform=ToTensor())
 
 
 def test_mnist_fedavg():
@@ -105,10 +125,7 @@ def test_mnist_fedavg():
 
 
 @pytest.mark.mpi(min_size=2)
-def test_mnist_fedavg_mpi():
-    print
-
-    from mpi4py import MPI
+def test_mnist_fedavg_mpi(): 
 
     comm = MPI.COMM_WORLD
     comm_rank = comm.Get_rank()
@@ -132,9 +149,6 @@ def test_mnist_fedavg_mpi():
 
 @pytest.mark.mpi(min_size=2)
 def test_mnist_iceadmm_mpi():
-
-    from mpi4py import MPI
-
     comm = MPI.COMM_WORLD
     comm_rank = comm.Get_rank()
     comm_size = comm.Get_size()
@@ -157,9 +171,6 @@ def test_mnist_iceadmm_mpi():
 
 @pytest.mark.mpi(min_size=2)
 def test_mnist_iiadmm_mpi():
-
-    from mpi4py import MPI
-
     comm = MPI.COMM_WORLD
     comm_rank = comm.Get_rank()
     comm_size = comm.Get_size()
@@ -181,7 +192,6 @@ def test_mnist_iiadmm_mpi():
 
 
 def test_mnist_fedavg_notest():
-
     num_clients = 2
     cfg = OmegaConf.structured(Config)
     cfg.fed.args.num_local_epochs=2
@@ -194,10 +204,6 @@ def test_mnist_fedavg_notest():
 
 @pytest.mark.mpi(min_size=2)
 def test_mnist_fedavg_mpi_notest():
-    print
-
-    from mpi4py import MPI
-
     comm = MPI.COMM_WORLD
     comm_rank = comm.Get_rank()
     comm_size = comm.Get_size()


### PR DESCRIPTION
By the previous CI update, the MNIST data was downloaded multiple times according to the number of MPI processes. This update allows MPI processes to download only once if the data does not exist.