### PR TITLE
Zilinghan/fedasync patch

### DIFF
--- a/examples/cifar10_async_mpi.py
+++ b/examples/cifar10_async_mpi.py
@@ -43,7 +43,7 @@ parser.add_argument('--mparam_2', type=float, required=False)
 parser.add_argument('--adapt_param', type=float, required=False)  
 
 ## Fed Async
-parser.add_argument("--gradient_based", type=bool, default=False, help="Whether the algorithm requires gradient from the model")
+parser.add_argument("--gradient_based", action="store_true", help="Whether the algorithm requires gradient from the model")
 parser.add_argument("--alpha", type=float, default=0.9, help="Mixing parameter for FedAsync Algorithm")
 parser.add_argument("--staleness_func", type=str, choices=['constant', 'polynomial', 'hinge'], default='polynomial')
 parser.add_argument("--a", type=float, default=0.5, help="First parameter for the staleness function")

--- a/examples/mnist_async_mpi.py
+++ b/examples/mnist_async_mpi.py
@@ -40,7 +40,7 @@ parser.add_argument("--mparam_2", type=float, required=False)
 parser.add_argument("--adapt_param", type=float, required=False)
 
 ## Fed Async
-parser.add_argument("--gradient_based", type=bool, default=False, help="Whether the algorithm requires gradient from the model")
+parser.add_argument("--gradient_based", action="store_true", help="Whether the algorithm requires gradient from the model")
 parser.add_argument("--alpha", type=float, default=0.9, help="Mixing parameter for FedAsync Algorithm")
 parser.add_argument("--staleness_func", type=str, choices=['constant', 'polynomial', 'hinge'], default='polynomial')
 parser.add_argument("--a", type=float, default=0.5, help="First parameter for the staleness function")

--- a/src/appfl/algorithm/server_fed_asynchronous.py
+++ b/src/appfl/algorithm/server_fed_asynchronous.py
@@ -25,6 +25,9 @@ class ServerFedAsynchronous(FedServer):
             stalness_func_name= self.staleness_func['name'],
             **self.staleness_func['args']
         )
+        self.list_named_parameters = []
+        for name in self.model.named_parameters():
+            self.list_named_parameters.append(name)
 
     def compute_pseudo_gradient(self, local_state: dict, client_idx: int):
         for name, _ in self.model.named_parameters():
@@ -43,8 +46,11 @@ class ServerFedAsynchronous(FedServer):
     def update(self, local_state: dict, init_step: int, client_idx: int):  
         self.global_state = copy.deepcopy(self.model.state_dict())
         self.compute_step(local_state, init_step, client_idx)
-        for name, _ in self.model.named_parameters():
-            self.global_state[name] += self.step[name]
+        for name in self.model.state_dict():
+            if name is self.list_named_parameters:
+                self.global_state[name] += self.step[name]
+            else:
+                self.global_state[name] = local_state[name]
         self.model.load_state_dict(self.global_state)
         self.global_step += 1
 

--- a/src/appfl/algorithm/server_fed_buffer.py
+++ b/src/appfl/algorithm/server_fed_buffer.py
@@ -8,7 +8,7 @@ logger = logging.getLogger(__name__)
 
 class ServerFedBuffer(FedServer):
     """ Implement FedBuffer algorithm
-        Asynchronous Federated Optimization: https://arxiv.org/abs/2106.06639
+        Federated Learning with Buffered Asynchronous Aggregation: https://arxiv.org/abs/2106.06639
     
     Agruments:
         weights: weight for each client
@@ -26,25 +26,34 @@ class ServerFedBuffer(FedServer):
             stalness_func_name= self.staleness_func['name'],
             **self.staleness_func['args']
         )
-        for name, _ in self.model.named_parameters():
+        for name in self.model.state_dict():
             self.pseudo_grad[name] = torch.zeros_like(self.model.state_dict()[name])
+        self.list_named_parameters = []
+        for name, _ in self.model.named_parameters():
+            self.list_named_parameters.append(name)
 
     def update_gradient(self, local_gradient: dict, init_step: int, client_idx: int):
-        for name, _ in self.model.named_parameters():
-            alpha_t = self.alpha * self.staleness(self.global_step - init_step)
-            self.pseudo_grad[name] += local_gradient[name]  * self.weights[client_idx] * alpha_t
+        alpha_t = self.alpha * self.staleness(self.global_step - init_step)
+        for name in self.model.state_dict():
+            if name in self.list_named_parameters:
+                self.pseudo_grad[name] += local_gradient[name]  * self.weights[client_idx] * alpha_t
+            else:
+                self.pseudo_grad[name] += local_gradient[name]
         self.counter += 1
 
     def update(self, local_gradient: dict, init_step: int, client_idx: int):  
         self.update_gradient(local_gradient, init_step, client_idx)
         if self.counter == self.K:
             self.global_state = copy.deepcopy(self.model.state_dict())
-            for name, _ in self.model.named_parameters():
-                self.global_state[name] -= self.pseudo_grad[name]
+            for name in self.model.state_dict():
+                if name is self.list_named_parameters:
+                    self.global_state[name] -= self.pseudo_grad[name]
+                else:
+                    self.global_state[name] = torch.div(self.pseudo_grad[name], self.counter)
             self.model.load_state_dict(self.global_state)
             self.global_step += 1
             self.counter = 0
-            for name, _ in self.model.named_parameters():
+            for name in self.model.state_dict():
                 self.pseudo_grad[name] = torch.zeros_like(self.model.state_dict()[name])
 
     def __staleness_func_factory(self, stalness_func_name, **kwargs):

--- a/src/appfl/algorithm/server_fed_buffer.py
+++ b/src/appfl/algorithm/server_fed_buffer.py
@@ -46,7 +46,7 @@ class ServerFedBuffer(FedServer):
         if self.counter == self.K:
             self.global_state = copy.deepcopy(self.model.state_dict())
             for name in self.model.state_dict():
-                if name is self.list_named_parameters:
+                if name in self.list_named_parameters:
                     self.global_state[name] -= self.pseudo_grad[name]
                 else:
                     self.global_state[name] = torch.div(self.pseudo_grad[name], self.counter)

--- a/src/appfl/misc/utils.py
+++ b/src/appfl/misc/utils.py
@@ -74,7 +74,10 @@ def create_custom_logger(logger, cfg: DictConfig):
 def client_log(dir, output_filename):
 
     if os.path.isdir(dir) == False:
-        os.mkdir(dir)
+        try:
+            os.mkdir(dir)
+        except:
+            pass
 
     file_ext = ".txt"
     filename = dir + "/%s%s" % (output_filename, file_ext)


### PR DESCRIPTION
Modifications to two main bugs:
(1) For some complicated model such as Resnet, there are some parameters not in `model.named_parameter()`, but we still need to handle them during the global aggregation by averaging those values, as how synchronous FL does in APPFL:
https://github.com/APPFL/APPFL/blob/7b4c44fd72058403739dbf1d0e3f2ca7895fe6ad/src/appfl/algorithm/server_federated.py#LL79C1-L87C17
Therefore, we modify FedAsync and FedBuffer algorithms correspondingly to account those parameters in the aggregation

(2) For running asynchronous algorithms with `gradient_based` choice (sending gradient instead of model), using `--gradient_based False` still gives `args.gradient_based=True` since python reads False as a string which evaluates to True when converting dtype to bool. So we use `--gradient_based, action="store_true"`, and now the user can enable the choice by simply using the `--gradient_based` flag.