### PR TITLE
Bugfix: Remove cfg.num_gpu Variable Usage

### DIFF
--- a/examples/celeba.py
+++ b/examples/celeba.py
@@ -131,7 +131,6 @@ def main():
     args.num_clients = len(train_datasets)
 
     model = get_model(args)
-    print(args)
     loss_fn = torch.nn.CrossEntropyLoss()   
     print(
         "----------Loaded Datasets and Model----------Elapsed Time=",

--- a/examples/celeba.py
+++ b/examples/celeba.py
@@ -107,8 +107,7 @@ def get_data(comm: MPI.Comm):
     return train_datasets, test_dataset
 
 
-def main():
-    print(args)
+def main():    
 
     comm = MPI.COMM_WORLD
     comm_rank = comm.Get_rank()
@@ -130,8 +129,7 @@ def main():
         )
 
     args.num_clients = len(train_datasets)       
-    
-    model = get_model(args)    
+    print(args)    
 
     loss_fn = torch.nn.CrossEntropyLoss()   
     print(

--- a/examples/celeba.py
+++ b/examples/celeba.py
@@ -128,8 +128,9 @@ def main():
             train_datasets, test_dataset, args.num_channel, args.num_pixel
         )
 
-    args.num_clients = len(train_datasets)       
-    print(args)    
+    args.num_clients = len(train_datasets)        
+
+    model = get_model(args)
 
     loss_fn = torch.nn.CrossEntropyLoss()   
     print(

--- a/examples/celeba.py
+++ b/examples/celeba.py
@@ -128,10 +128,10 @@ def main():
             train_datasets, test_dataset, args.num_channel, args.num_pixel
         )
 
-    args.num_clients = len(train_datasets)        
+    args.num_clients = len(train_datasets)
 
     model = get_model(args)
-
+    print(args)
     loss_fn = torch.nn.CrossEntropyLoss()   
     print(
         "----------Loaded Datasets and Model----------Elapsed Time=",

--- a/src/appfl/run_mpi.py
+++ b/src/appfl/run_mpi.py
@@ -253,7 +253,7 @@ def run_client(
     if "cuda" in cfg.device:
         ## Check available GPUs if CUDA is used
         num_gpu = torch.cuda.device_count()
-        clientpergpu = math.ceil(num_clients/cfg.num_gpu)
+        clientpergpu = math.ceil(num_clients/num_gpu)
 
     clients = []
     for _, cid in enumerate(num_client_groups[comm_rank - 1]):


### PR DESCRIPTION
This bugfix removes the usage of the num_gpu variable from the config object. Although the variable was removed from the config object from the last merging, there was the remained usage and the usage generated the error. 