### PR TITLE
Fix for MPI asynchronous

### DIFF
--- a/examples/mnist_mpi_async.py
+++ b/examples/mnist_mpi_async.py
@@ -64,7 +64,8 @@ parser.add_argument("--server_lr", type=float, default=0.01)
 parser.add_argument("--mparam_1", type=float, default=0.9)
 parser.add_argument("--mparam_2", type=float, default=0.99)
 parser.add_argument("--adapt_param", type=float, default=0.001)
-
+parser.add_argument("--validation", action="store_true")
+                    
 ## loss function
 parser.add_argument("--loss_fn", type=str, required=False, help="path to the custom loss function definition file, use cross-entropy loss by default if no path is specified")
 parser.add_argument("--loss_fn_name", type=str, required=False, help="class name for the custom loss in the loss function definition file, choose the first class by default if no name is specified")
@@ -145,6 +146,7 @@ def main():
     ## server
     cfg.fed.servername = args.server
     cfg.num_epochs = args.num_epochs
+    cfg.validation = args.validation
 
     ## outputs
     cfg.use_tensorboard = False

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setuptools.setup(
     packages=setuptools.find_packages(where="src"),
     python_requires=">=3.6",
     install_requires=[
-        "numpy",
+        "numpy==1.26.4",
         "torch",
         "grpcio",
         "grpcio-tools",

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,4 @@
+import sys
 import setuptools
 
 # Build Author list
@@ -23,6 +24,11 @@ for i, (k, v) in enumerate(authors.items()):
 with open("README.md", "r", encoding="utf-8") as fh:
     long_description = fh.read()
 
+if sys.version_info >= (3, 9):
+    numpy_version = 'numpy==1.26.4'
+else:
+    numpy_version = 'numpy'  # Default numpy version for Python < 3.9
+
 setuptools.setup(
     name="appfl",
     version="0.4.2",
@@ -43,7 +49,7 @@ setuptools.setup(
     packages=setuptools.find_packages(where="src"),
     python_requires=">=3.6",
     install_requires=[
-        "numpy==1.26.4",
+        numpy_version,
         "torch",
         "grpcio",
         "grpcio-tools",

--- a/src/appfl/compressor/compressor.py
+++ b/src/appfl/compressor/compressor.py
@@ -7,7 +7,11 @@ from typing import Tuple, Union, List
 import numpy as np
 import pickle
 from . import pyszx
-import zfpy
+try:
+    import zfpy
+    _ZFP_COMPATIBLE = True
+except:
+    _ZFP_COMPATIBLE = False
 import zstd
 import torch
 import gzip
@@ -163,6 +167,9 @@ class Compressor:
             )
             return compressed_arr.tobytes()
         elif self.cfg.lossy_compressor == "ZFP":
+            if not _ZFP_COMPATIBLE:
+                err_msg = f"ZFP compressor is not compatible with your current numpy version: {np.__version__}, please use numpy<2.0.0"
+                raise ImportError(err_msg)
             if self.cfg.error_bounding_mode == "ABS":
                 return zfpy.compress_numpy(ori_data, tolerance=self.cfg.error_bound)
             elif self.cfg.error_bounding_mode == "REL":
@@ -289,6 +296,8 @@ class Compressor:
             )
             return decompressed_arr
         elif self.cfg.lossy_compressor == "ZFP":
+            if not _ZFP_COMPATIBLE:
+                raise ImportError(f"ZFP is not compatible with your current numpy version: {np.__version__}, please use numpy<2.0.0")
             return zfpy.decompress_numpy(cmp_data)
         else:
             raise NotImplementedError


### PR DESCRIPTION
fix #192 

In the original code, the clients are stored in the order of MPI ranks (client IDs). This can cause the unintentionally frequent update to the first few clients. This fix changes the code to store and address the clients as a FIFO queue.