### PR TITLE
Update aggregator module, easy integration of new aggregator/trainer, and new tutorial

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+local_tests
 .vscode
 .gitignore
 creds

--- a/docs/changelog/index.rst
+++ b/docs/changelog/index.rst
@@ -1,6 +1,16 @@
 Changelog
 =========
 
+appfl v1.0.1
+------------
+
+New Features
+~~~~~~~~~~~~
+
+- For the aggregators, the model architecture is set to be an optional initialization parameter, and the aggregators only aggregate the parameters sent by the clients instead of the whole set of model parameters. This is useful when doing federated fine-tuning or federated transfer learning where only part of model parameters are updated / the model architecture is unknown to the aggregator.
+- Support easy integration of custom trainer/aggregator: user only needs to provide the custom trainer/aggregator class name and the path to the definition file in the configuration file to use it, instead of modifying the source code.
+- Add a detailed step-by-step tutorial on how to use ``APPFL`` to fine-tune a ViT model with a custom trainer.
+
 appfl v1.0.0
 ------------
 

--- a/docs/developer/algorithms.rst
+++ b/docs/developer/algorithms.rst
@@ -16,11 +16,11 @@ To add new aggregators to ``APPFL``,  you can create your own aggregator class b
         def __init__(
             self,
             model: torch.nn.Module,
-            aggregator_config: DictConfig,
+            aggregator_configs: DictConfig,
             logger: Any
         ):
             self.model = model
-            self.aggregator_config = aggregator_config
+            self.aggregator_configs = aggregator_configs
             self.logger = logger
             ...
         
@@ -34,7 +34,7 @@ To add new aggregators to ``APPFL``,  you can create your own aggregator class b
             """Return global model parameters"""
             pass
 
-You may add any configuration parameters into your aggregator and access them using ``self.aggregator_config.your_config_param``. When you start the FL experiment, you can specify the aggregator configuration parameter values in the server configuration file in the following way:
+You may add any configuration parameters into your aggregator and access them using ``self.aggregator_configs.your_config_param``. When you start the FL experiment, you can specify the aggregator configuration parameter values in the server configuration file in the following way:
 
 .. code-block:: yaml
 

--- a/docs/tutorials/examples/vit_ft/appfl_vit_finetuning_client/config.yaml
+++ b/docs/tutorials/examples/vit_ft/appfl_vit_finetuning_client/config.yaml
@@ -1,0 +1,18 @@
+train_configs:
+  # Device
+  device: "cpu"
+  # Logging and outputs
+  logging_id: "Client1"
+  logging_output_dirname: "./output"
+  logging_output_filename: "result"
+
+# Local dataset
+data_configs:
+  dataset_path: "./resources/vit_fake_dataset.py"
+  dataset_name: "get_vit_fake_dataset"
+
+comm_configs:
+  grpc_configs:
+    server_uri: localhost:50051
+    max_message_size: 1048576
+    use_ssl: False

--- a/docs/tutorials/examples/vit_ft/appfl_vit_finetuning_client/resources/vit_fake_dataset.py
+++ b/docs/tutorials/examples/vit_ft/appfl_vit_finetuning_client/resources/vit_fake_dataset.py
@@ -1,0 +1,39 @@
+import torch
+from torch.utils.data import Dataset
+
+class RandomImageDataset(Dataset):
+    def __init__(self, num_images=100, height=224, width=224, channels=3):
+        """
+        Initialize the dataset with the given parameters.
+        :param num_images: Number of random images.
+        :param height: Height of each image.
+        :param width: Width of each image.
+        :param channels: Number of channels (e.g., 3 for RGB).
+        """
+        self.num_images = num_images
+        self.height = height
+        self.width = width
+        self.channels = channels
+        # Pre-generate all images (optional, could generate on the fly in __getitem__)
+        self.images = torch.randn(num_images, channels, height, width)
+        self.labels = torch.randint(0, 2, (num_images,))
+
+    def __len__(self):
+        """
+        Return the total number of images in the dataset.
+        """
+        return self.num_images
+
+    def __getitem__(self, idx):
+        """
+        Retrieve an image by index.
+        :param idx: Index of the image to retrieve.
+        :return: Image tensor.
+        """
+        return self.images[idx], self.labels[idx]
+
+def get_vit_fake_dataset():
+    """
+    Return a random training dataset and a random test dataset.
+    """
+    return RandomImageDataset(num_images=100), RandomImageDataset(num_images=10)

--- a/docs/tutorials/examples/vit_ft/appfl_vit_finetuning_client/run_client.py
+++ b/docs/tutorials/examples/vit_ft/appfl_vit_finetuning_client/run_client.py
@@ -1,0 +1,38 @@
+import argparse
+from omegaconf import OmegaConf
+from appfl.agent import ClientAgent
+from appfl.comm.grpc import GRPCClientCommunicator
+
+argparser = argparse.ArgumentParser()
+argparser.add_argument("--config", type=str, default="config.yaml")
+args = argparser.parse_args()
+
+# Load the configuration file
+client_agent_config = OmegaConf.load(args.config)
+
+# Create the client agent and communicator
+client_agent = ClientAgent(client_agent_config=client_agent_config)
+client_communicator = GRPCClientCommunicator(
+    client_id = client_agent.get_id(),
+    **client_agent_config.comm_configs.grpc_configs,
+)
+
+# Get general configurations from the server
+client_config = client_communicator.get_configuration()
+client_agent.load_config(client_config)
+
+# Get the initial global model from the server
+init_global_model = client_communicator.get_global_model(init_model=True)
+client_agent.load_parameters(init_global_model)
+
+# Local training loop
+while True:
+    client_agent.train()
+    local_model = client_agent.get_parameters()
+    new_global_model, metadata = client_communicator.update_global_model(local_model)
+    if metadata['status'] == 'DONE':
+        break
+    client_agent.load_parameters(new_global_model)
+    
+# Close the connection
+client_communicator.invoke_custom_action(action='close_connection')

--- a/docs/tutorials/examples/vit_ft/appfl_vit_finetuning_server/config.yaml
+++ b/docs/tutorials/examples/vit_ft/appfl_vit_finetuning_server/config.yaml
@@ -1,0 +1,46 @@
+# General client configurations
+client_configs:
+  train_configs:
+    # Local trainer
+    trainer: "ViTFineTuningTrainer"
+    trainer_path: "./resources/vit_ft_trainer.py"
+    mode: "step"
+    num_local_steps: 10
+    optim: "Adam"
+    optim_args:
+      lr: 0.001
+      weight_decay: 0.0
+    # Loss function
+    loss_fn: "CrossEntropyLoss"
+    # Client validation
+    do_validation: True
+    do_pre_validation: True
+    metric_path: "./resources/metric.py"
+    metric_name: "accuracy"
+    # Data loader
+    train_batch_size: 1
+    val_batch_size: 1
+    train_data_shuffle: True
+    val_data_shuffle: False
+  model_configs:
+    model_path: "./resources/vit.py"
+    model_name: "get_vit"
+
+# Server specific configurations
+server_configs:
+  aggregator: "FedAvgAggregator"
+  aggregator_kwargs:
+    client_weights_mode: "equal"
+  scheduler: "SyncScheduler"
+  scheduler_kwargs:
+    num_clients: 2
+    same_init_model: True
+  device: "cpu"
+  num_global_epochs: 10
+  logging_output_dirname: "./output"
+  logging_output_filename: "result"
+  comm_configs:
+    grpc_configs:
+      server_uri: localhost:50051
+      max_message_size: 1048576
+      use_ssl: False

--- a/docs/tutorials/examples/vit_ft/appfl_vit_finetuning_server/resources/metric.py
+++ b/docs/tutorials/examples/vit_ft/appfl_vit_finetuning_server/resources/metric.py
@@ -1,0 +1,13 @@
+import numpy as np
+
+def accuracy(y_true, y_pred):
+    '''
+    y_true and y_pred are both of type np.ndarray
+    y_true (N, d) where N is the size of the validation set, and d is the dimension of the label
+    y_pred (N, D) where N is the size of the validation set, and D is the output dimension of the ML model
+    '''
+    if len(y_pred.shape) == 1:
+        y_pred = np.round(y_pred)
+    else:
+        y_pred = y_pred.argmax(axis=1)
+    return 100*np.sum(y_pred==y_true)/y_pred.shape[0]

--- a/docs/tutorials/examples/vit_ft/appfl_vit_finetuning_server/resources/vit.py
+++ b/docs/tutorials/examples/vit_ft/appfl_vit_finetuning_server/resources/vit.py
@@ -1,0 +1,19 @@
+import torch
+from torchvision.models import vit_b_16, ViT_B_16_Weights
+
+def get_vit():
+    """
+    Return a pretrained ViT with all layers frozen except output head.
+    """
+
+    # Instantiate a pre-trained ViT-B on ImageNet
+    model = vit_b_16(weights=ViT_B_16_Weights.IMAGENET1K_V1)
+    in_features = model.heads[-1].in_features
+    model.heads[-1] = torch.nn.Linear(in_features, 2)
+
+    # Disable gradients for everything
+    model.requires_grad_(False)
+    # Now enable just for output head
+    model.heads.requires_grad_(True)
+
+    return model

--- a/docs/tutorials/examples/vit_ft/appfl_vit_finetuning_server/resources/vit_ft_trainer.py
+++ b/docs/tutorials/examples/vit_ft/appfl_vit_finetuning_server/resources/vit_ft_trainer.py
@@ -1,0 +1,11 @@
+from typing import Dict
+from appfl.algorithm.trainer import VanillaTrainer
+
+class ViTFineTuningTrainer(VanillaTrainer):
+    def get_parameters(self) -> Dict:
+        return {
+            k: v.cpu() for k, v in self.model.heads.state_dict().items()
+        }
+        
+    def load_parameters(self, params: Dict):
+        self.model.heads.load_state_dict(params, strict=False)

--- a/docs/tutorials/examples/vit_ft/appfl_vit_finetuning_server/run_server.py
+++ b/docs/tutorials/examples/vit_ft/appfl_vit_finetuning_server/run_server.py
@@ -1,0 +1,24 @@
+import argparse
+from omegaconf import OmegaConf
+from appfl.agent import ServerAgent
+from appfl.comm.grpc import GRPCServerCommunicator, serve
+
+argparser = argparse.ArgumentParser()
+argparser.add_argument("--config", type=str, default="config.yaml")
+args = argparser.parse_args()
+
+# Load the configuration file
+server_agent_config = OmegaConf.load(args.config)
+
+# Create a server agent
+server_agent = ServerAgent(server_agent_config=server_agent_config)
+
+# Create a GRPC communicator using the server agent
+communicator = GRPCServerCommunicator(
+    server_agent,
+    max_message_size=server_agent_config.server_configs.comm_configs.grpc_configs.max_message_size,
+    logger=server_agent.logger,
+)
+
+# Start serving
+serve(communicator, **server_agent_config.server_configs.comm_configs.grpc_configs)

--- a/docs/tutorials/examples_vit_finetuning.rst
+++ b/docs/tutorials/examples_vit_finetuning.rst
@@ -1,0 +1,261 @@
+Example: Finetune a Vision Transformer model
+============================================
+
+``APPFL`` aims to make the transition from centralized to federated learning (FL) as seamless as possible, and this tutorial will demonstrate how to finetune a Vision Transformer (ViT) model in federated settings using the ``APPFL`` package.
+
+Centralized learning
+--------------------
+
+In centralized learning, to train a machine learning model, we need a "trainer" that trains the model on a training dataset and evalutes it using an evaluation dataset. The key components of this process are the following:
+
+- Model: A machine learning model that we want to train.
+- Datasets: Datasets that contain the training and evaluation data.
+- Trainer: Algorithm that trains the model on the training dataset and evaluates it on the evaluation dataset, more specifically, its key components are:
+
+    (1) Loss function for updating the model parameters.
+    (2) Optimizer and its hyperparameters (e.g., learning rate, momentum, etc.)
+    (3) Metric function that measures the performance of the model.
+    (4) Other hyperparameters (e.g., batch size, number of epochs/steps, etc.)
+
+From centralized to federated learning
+--------------------------------------
+
+To move from centralized learning to fedearated learning, the following additional components are needed
+
+- Exchanged parameters: What parameters are exchanged between the server and clients for aggregation purposes.
+- Aggregation algorithms: How the parameters are aggregated.
+- Other hyperparameters (e.g., number of clients, number of communication rounds, etc.)
+
+In addition, we need to consider how to efficiently configure the distributed training process. In ``APPFL``, we choose to use a server configuration YAML file to specify necessary server-specific configurations (e.g., aggregation algorithm, number of communication rounds, number of clients, etc.) as well as general client configurations that should be the same for all clients (e.g., model architecture, trainer, loss function, metric function, optimizer and its hyperparameters, batch size, number of local epochs/steps, etc.). All these general client configurations will be shared with all clients at the beginning of the training process.
+
+As for clients, in addition to the configurations shared from the server, each client should have its own configuration YAML file to specify client-specific configurations (e.g., functions for loading local private datasets, device, logging settings, etc.).
+
+FL server configurations
+------------------------
+
+Server directory structure
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Below shows the directory structure for the FL server. 
+
+.. code-block:: text
+
+    appfl_vit_finetuning_server
+    ├── resources
+    │   ├── vit.py                  # Model architecture
+    │   ├── metric.py               # Metric function
+    │   └── vit_ft_trainer.py       # Trainer
+    ├── config.yaml                 # Server configuration file
+    └── run_server.py               # Server launching script
+
+Now let's take a look at each file.
+
+Model architecture, metric function, and trainer
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The ``resources/vit.py`` file contains a function that defines the ViT model architecture and freezes all layers except the last heads layer.
+
+.. literalinclude:: ./examples/vit_ft/appfl_vit_finetuning_server/resources/vit.py
+    :language: python
+    :caption: resources/vit.py - ViT model architecture
+
+The ``resources/metric.py`` file contains the metric function that computes the accuracy of the model outputs.
+
+.. literalinclude:: ./examples/vit_ft/appfl_vit_finetuning_server/resources/metric.py
+    :language: python
+    :caption: resources/metric.py - Metric function
+
+The ``resources/vit_ft_trainer.py`` file defines a trainer class for fine-tuning the ViT model. Specifically, it inherits the ``VanillaTrainer`` class from the ``appfl.algorithm.trainer`` module and overrides the ``get_parameters`` and ``load_parametes`` methods for only exchanging the heads layer parameters of the ViT model between the server and clients.
+
+.. note::
+
+    The ``VanillaTrainer`` is a trainer class that trains a model using the specified optimizer and loss function for several epochs or steps (i.e. batches), evaluates it using the given metric function, and finally returns the whole set of model parameters for aggregation. It is a good starting point for building your own trainer class. For this fine-tuning example, we only need to override the ``get_parameters`` and ``load_parameters`` methods to exchange only the heads layer parameters of the ViT model.
+
+.. literalinclude:: ./examples/vit_ft/appfl_vit_finetuning_server/resources/vit_ft_trainer.py
+    :language: python
+    :caption: resources/vit_ft_trainer.py - Trainer
+
+Server configuration file
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The ``config.yaml`` is the server YAML configuration file, which contains both general client configurations (``client_configs``) and server-specific configurations (``server_configs``). 
+
+.. literalinclude:: ./examples/vit_ft/appfl_vit_finetuning_server/config.yaml
+    :language: yaml
+    :caption: config.yaml - Server configuration file
+
+Here comes the line-by-line explanation of ``client_configs`` part:
+
+- ``train_configs``: It contains all necessary configurations related to the local trainer.
+- ``train_configs.trainer``: The name of the trainer class you want to use.
+- ``train_configs.trainer_path``: The path to the file that defines the trainer class [Note: there is no need to specify this if you are using the ``VanillaTrainer`` class provided by the ``APPFL`` package].
+- ``train_configs.mode``: The mode of training, either ``epoch`` or ``step``, where ``epoch`` means, in each local training round, training the model for a fixed number of epochs, and ``step`` means training the model for a fixed number of steps.
+- ``train_configs.num_local_steps``: The number of local steps for each client if ``mode="step"``. [Note: Use ``num_local_epochs`` if you set ``mode="epoch"``].
+- ``train_configs.optim``: The optimizer name available in the ``torch.optim`` module to use for training.
+- ``train_configs.optim_args``: The hyperparameters of the optimizer.
+- ``train_configs.loss_fn``: The loss function name available in the ``torch.nn`` module to use for training. [Note: You can also use a custom loss function, refer `here <../users/user_loss.html>`_ for instructions].
+- ``train_configs.do_validation``: Whether the clients should perform validation after each local training round.
+- ``train_configs.do_pre_validation``: Whether the clients should perform validation before each local training round (i.e., evaluate the received model parameters from the server).
+- ``train_configs.metric_path``: The path to the file that defines the metric function [Note: see `here <../users/user_metric.html>`_ for insturctions on defining metric functions].
+- ``train_configs.metric_name``: The name of the metric function you want to use.
+- ``train_configs.train_batch_size``: The batch size for training.
+- ``train_configs.val_batch_size``: The batch size for validation.
+- ``train_configs.train_data_shuffle``: Whether to shuffle the training data.
+- ``train_configs.val_data_shuffle``: Whether to shuffle the validation data.
+- ``model_configs``: It contains necessary information to load the model from the definition file - ``model_path`` is the absolute/relative path to the model definition file, ``model_name`` is the name of the model definition function. [Note: You can also load the model from a class definition. For more information, refer `here <../users/user_model.html>`_].
+
+Here comes the line-by-line explanation of ``server_configs`` part:
+
+- ``server_configs.aggregator``: The name of the aggregation algorithm provided by ``APPFL`` you want to use. Please refer to `here <../users/aggregator.html#available-aggregators>`_ for the list of provided aggregators. This can also be a custom aggregation algorithm, in which case you need to provide the path to the file that defines the custom aggregation algorithm in the ``aggregator_path`` field.
+- ``server_configs.aggregator_kwargs``: The hyperparameters of the aggregation algorithm. In this example, ``client_weights_mode='equal'`` means that all clients have equal weights in the aggregation process, while ``client_weights_mode='sample_size'`` means that the weights of the clients are proportional to the number of samples they have.
+- ``server_configs.scheduler``: The name of the scheduling algorithm provided by ``APPFL`` you want to use. As FedAvg is a synchronous algorithm we set it to be ``SyncScheduler`` here [Please refer to `here <../users/scheduler.html>`_ for the list of provided schedulers].
+- ``server_configs.scheduler_kwargs``: The hyperparameters of the scheduling algorithm.  ``num_clients`` tells the scheduler the total number of clients in the training process, and ``same_init_model=True`` ensures that all clients start with the same initial model parameters.
+- ``server_configs.device``: The device on which the server should run. 
+- ``server_configs.num_global_epochs``: The number of FL global communication epochs.
+- ``server_configs.logging_output_dirname``: The directory name where the server logs will be saved.
+- ``server_configs.logging_output_filename``: The filename where the server logs will be saved.
+- ``comm_configs.grpc_configs``: It contains necessary configurations for the gRPC communication process - ``server_uri`` is the URI and port number where the server will be running,  ``max_message_size`` is the maximum size of each message, if the message size exceeds this value, the message will be automatically split into smaller messages, ``use_ssl`` is a boolean value that determines whether to use SSL for communication.
+
+.. note::
+
+    To enable SSL communication, you need to provide the server and client with the necessary SSL certificates. Specifically, the server needs a certificate and a certificate key, and set the path to these files in the ``server_configs.comm_configs.grpc_configs.server_certificate`` and ``server_configs.comm_configs.grpc_configs.server_certificate_key`` fields, respectively. The client needs a certificate authority (CA) certificate, and set the path to this file in the ``client_configs.comm_configs.grpc_configs.root_certificate`` field.
+
+
+Server launch script
+~~~~~~~~~~~~~~~~~~~~
+
+Below is the server launch script that reads the server configuration file, initializes the server agent, creates a gRPC server communicator, and finally starts serving.
+
+.. literalinclude:: ./examples/vit_ft/appfl_vit_finetuning_server/run_server.py
+    :language: python
+    :caption: run_server.py - Server launch script
+
+User can run the server by executing the following command in a terminal:
+
+.. code-block:: bash
+
+    python run_server.py
+
+FL client configurations
+------------------------
+
+Client directory structure
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Below shows the directory structure for the FL client.
+
+.. code-block:: text
+
+    appfl_vit_finetuning_client
+    ├── resources
+    │   └── vit_fake_dataset.py      # Dataset loader
+    ├── config.yaml                  # Client configuration file
+    └── run_client.py                # Client launching script
+
+Now let's take a look at each file.
+
+Dataset loader
+~~~~~~~~~~~~~~
+
+The ``resources/vit_fake_dataset.py`` file contains a function that generates a fake dataset for the client. In this example, we generate a fake dataset using the ``torch.utils.data.Dataset`` class which randomly returns a 3x224x224 tensor input image and a binary label for each data sample.
+
+.. literalinclude:: ./examples/vit_ft/appfl_vit_finetuning_client/resources/vit_fake_dataset.py
+    :language: python
+    :caption: resources/vit_fake_dataset.py - Dataset loader
+
+Client configuration file
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The ``config.yaml`` is the client YAML configuration file, which contains client-specific configurations, such as the information of the dataset loader function, device, logging settings, etc.
+
+.. literalinclude:: ./examples/vit_ft/appfl_vit_finetuning_client/config.yaml
+    :language: yaml
+    :caption: config.yaml - Client configuration file
+
+Client launch script
+~~~~~~~~~~~~~~~~~~~~
+
+Below is the client launch script. It reads the client configuration file to initialize a client agent and a gRPC client communicator. It then employs the client communicator sends various types of requests to the launched server to do fedearated learning:
+
+(1) The client first uses the communicator to request general client configurations from the server and loads them.
+(2) It then gets the initial global model parameters from the server.
+(3) It then starts the (local training + global aggregation) loop until receiving a "DONE" status flag from the server.
+(4) Finally, it sends a `close_connection` action to the server to close the connection.
+
+.. literalinclude:: ./examples/vit_ft/appfl_vit_finetuning_client/run_client.py
+    :language: python
+    :caption: run_client.py - Client launch script
+
+User can run the client by executing the following command:
+
+.. code-block:: bash
+
+    python run_client.py
+
+.. note::
+
+    As in the provided server configuration, the ``num_clients`` is set to 2, you need to run the client script twice in two separate terminals.
+
+Result Logs
+-----------
+
+After running ``run_server.py`` in one terminal, and ``run_client.py`` in two separate terminals, you should see the following output in the server terminal:
+
+.. code-block:: text
+
+    [2024-09-01 14:58:20,081 INFO server]: Logging to ./output/result_Server_2024-09-01-14:58:20.txt
+    [2024-09-01 14:58:20,081 INFO server]: Setting seed value to 42
+    [2024-09-01 14:58:23,892 INFO server]: Received GetConfiguration request from client 12e7104d-eeb9-4f22-a421-d4b4f8cdaa91
+    [2024-09-01 14:58:24,671 INFO server]: Received GetGlobalModel request from client 12e7104d-eeb9-4f22-a421-d4b4f8cdaa91
+    [2024-09-01 14:58:27,148 INFO server]: Received GetConfiguration request from client 0b5f9d48-10d3-4398-9e7b-485886399191
+    [2024-09-01 14:58:27,899 INFO server]: Received GetGlobalModel request from client 0b5f9d48-10d3-4398-9e7b-485886399191
+    [2024-09-01 14:58:41,964 INFO server]: Received UpdateGlobalModel request from client 0b5f9d48-10d3-4398-9e7b-485886399191
+    [2024-09-01 14:58:42,087 INFO server]: Received UpdateGlobalModel request from client 12e7104d-eeb9-4f22-a421-d4b4f8cdaa91
+    [2024-09-01 14:58:44,349 INFO server]: Received UpdateGlobalModel request from client 0b5f9d48-10d3-4398-9e7b-485886399191
+    [2024-09-01 14:58:44,421 INFO server]: Received UpdateGlobalModel request from client 12e7104d-eeb9-4f22-a421-d4b4f8cdaa91
+    [2024-09-01 14:58:46,745 INFO server]: Received UpdateGlobalModel request from client 0b5f9d48-10d3-4398-9e7b-485886399191
+    [2024-09-01 14:58:46,796 INFO server]: Received UpdateGlobalModel request from client 12e7104d-eeb9-4f22-a421-d4b4f8cdaa91
+    [2024-09-01 14:58:49,228 INFO server]: Received UpdateGlobalModel request from client 0b5f9d48-10d3-4398-9e7b-485886399191
+    [2024-09-01 14:58:49,269 INFO server]: Received UpdateGlobalModel request from client 12e7104d-eeb9-4f22-a421-d4b4f8cdaa91
+    [2024-09-01 14:58:51,687 INFO server]: Received UpdateGlobalModel request from client 12e7104d-eeb9-4f22-a421-d4b4f8cdaa91
+    [2024-09-01 14:58:51,714 INFO server]: Received UpdateGlobalModel request from client 0b5f9d48-10d3-4398-9e7b-485886399191
+    [2024-09-01 14:58:54,159 INFO server]: Received UpdateGlobalModel request from client 12e7104d-eeb9-4f22-a421-d4b4f8cdaa91
+    [2024-09-01 14:58:54,209 INFO server]: Received UpdateGlobalModel request from client 0b5f9d48-10d3-4398-9e7b-485886399191
+    [2024-09-01 14:58:56,651 INFO server]: Received UpdateGlobalModel request from client 12e7104d-eeb9-4f22-a421-d4b4f8cdaa91
+    [2024-09-01 14:58:56,731 INFO server]: Received UpdateGlobalModel request from client 0b5f9d48-10d3-4398-9e7b-485886399191
+    [2024-09-01 14:58:59,286 INFO server]: Received UpdateGlobalModel request from client 0b5f9d48-10d3-4398-9e7b-485886399191
+    [2024-09-01 14:58:59,309 INFO server]: Received UpdateGlobalModel request from client 12e7104d-eeb9-4f22-a421-d4b4f8cdaa91
+    [2024-09-01 14:59:01,832 INFO server]: Received UpdateGlobalModel request from client 12e7104d-eeb9-4f22-a421-d4b4f8cdaa91
+    [2024-09-01 14:59:01,943 INFO server]: Received UpdateGlobalModel request from client 0b5f9d48-10d3-4398-9e7b-485886399191
+    [2024-09-01 14:59:04,503 INFO server]: Received UpdateGlobalModel request from client 0b5f9d48-10d3-4398-9e7b-485886399191
+    [2024-09-01 14:59:04,583 INFO server]: Received UpdateGlobalModel request from client 12e7104d-eeb9-4f22-a421-d4b4f8cdaa91
+    [2024-09-01 14:59:04,585 INFO server]: Received InvokeCustomAction close_connection request from client 12e7104d-eeb9-4f22-a421-d4b4f8cdaa91
+    [2024-09-01 14:59:04,585 INFO server]: Received InvokeCustomAction close_connection request from client 0b5f9d48-10d3-4398-9e7b-485886399191
+    Terminating the server ...
+
+And the following output in the client terminals:
+
+.. code-block:: text
+
+    [2024-09-01 14:58:27,005 INFO Client1]: Logging to ./output/result_Client1_2024-09-01-14:58:27.txt
+    [2024-09-01 14:58:39,355 INFO Client1]:      Round   Pre Val?       Time Train Loss Train Accuracy   Val Loss Val Accuracy
+    [2024-09-01 14:58:40,338 INFO Client1]:          0          Y                                          0.7158      30.0000
+    [2024-09-01 14:58:41,871 INFO Client1]:          0          N     1.5323     0.0862        50.0000     0.6990      50.0000
+    [2024-09-01 14:58:42,826 INFO Client1]:          1          Y                                          0.6316      70.0000
+    [2024-09-01 14:58:44,299 INFO Client1]:          1          N     1.4725     0.0704        60.0000     1.4802      30.0000
+    [2024-09-01 14:58:45,161 INFO Client1]:          2          Y                                          0.9973      30.0000
+    [2024-09-01 14:58:46,721 INFO Client1]:          2          N     1.5584     0.0725        70.0000     1.0347      30.0000
+    [2024-09-01 14:58:47,600 INFO Client1]:          3          Y                                          1.3194      30.0000
+    [2024-09-01 14:58:49,204 INFO Client1]:          3          N     1.6029     0.1010        30.0000     0.6233      70.0000
+    [2024-09-01 14:58:50,091 INFO Client1]:          4          Y                                          0.6168      70.0000
+    [2024-09-01 14:58:51,694 INFO Client1]:          4          N     1.6034     0.0727        60.0000     0.9816      30.0000
+    [2024-09-01 14:58:52,598 INFO Client1]:          5          Y                                          0.8828      30.0000
+    [2024-09-01 14:58:54,189 INFO Client1]:          5          N     1.5906     0.0759        30.0000     0.7135      30.0000
+    [2024-09-01 14:58:55,048 INFO Client1]:          6          Y                                          0.6543      70.0000
+    [2024-09-01 14:58:56,708 INFO Client1]:          6          N     1.6591     0.0833        40.0000     0.7175      30.0000
+    [2024-09-01 14:58:57,596 INFO Client1]:          7          Y                                          0.7486      30.0000
+    [2024-09-01 14:58:59,262 INFO Client1]:          7          N     1.6647     0.0673        60.0000     0.6146      70.0000
+    [2024-09-01 14:59:00,216 INFO Client1]:          8          Y                                          0.6415      70.0000
+    [2024-09-01 14:59:01,924 INFO Client1]:          8          N     1.7078     0.0775        40.0000     0.6073      70.0000
+    [2024-09-01 14:59:02,819 INFO Client1]:          9          Y                                          0.6165      70.0000
+    [2024-09-01 14:59:04,483 INFO Client1]:          9          N     1.6634     0.0493        90.0000     1.0570      70.0000

--- a/docs/tutorials/index.rst
+++ b/docs/tutorials/index.rst
@@ -10,4 +10,5 @@ We present a collection of tutorials for APPFL framework.
     ../notebooks/index
     gpuclusterrun
     aws
+    examples_vit_finetuning
     deprecated_tutorial

--- a/docs/users/user_model.rst
+++ b/docs/users/user_model.rst
@@ -1,8 +1,15 @@
 How to define model
 ===================
 
-User-defined models can be anything derived from ``torch.nn.Module`` with any keyword arguments necessay.
-For example, we can define a fully connected (FC) layer as follows:
+``APPFL`` allows users to define their own models for federated learning in two ways:
+
+1. Load the model from a class defined in a Python file.
+2. Load the model from a Python function that returns the model.
+
+Load model from a class
+-----------------------
+
+User-defined model can be any class derived from ``torch.nn.Module`` with any keyword arguments necessary. For example, we can define a fully connected (FC) layer as follows:
 
 .. code-block:: python
 
@@ -19,7 +26,7 @@ For example, we can define a fully connected (FC) layer as follows:
             out = self.fc(x)
             return out 
 
-To use the model, you need to provide the absolute/relative path to the model definition file, the name of the model class, and the keyword arguments to the model class. For example, to use the FC layer defined above, you can add the following lines to the server configuration file:
+To use the model, users need to provide the absolute/relative path to the model definition file, the name of the model class, and the keyword arguments to the model class if needed. For example, to use the FC layer defined above, users can add the following lines to the server configuration file:
 
 .. code-block:: yaml
     
@@ -30,4 +37,43 @@ To use the model, you need to provide the absolute/relative path to the model de
             model_name: "FC"
             model_kwargs:
                 input_size: 39
+        ...
+
+Load model from a function
+--------------------------
+
+Sometimes, it could be more convenient to define the model from a function that returns the model, allowing users to easily perform actions such as loading pretrained weigths, freezing certain layers, changing the output head, etc. For example, we define a function that returns a pretrained Vision Transformer (ViT) model with certain frozen layers for binary classification as follows:
+
+.. code-block:: python
+
+    import torch
+    from torchvision.models import vit_b_16, ViT_B_16_Weights
+
+    def get_vit():
+        """
+        Return a pretrained ViT with all layers frozen except output head.
+        """
+
+        # Instantiate a pre-trained ViT-B on ImageNet
+        model = vit_b_16(weights=ViT_B_16_Weights.IMAGENET1K_V1)
+
+        in_features = model.heads[-1].in_features
+        model.heads[-1] = torch.nn.Linear(in_features, 2)
+
+        # Disable gradients for everything
+        model.requires_grad_(False)
+        # Now enable just for output head
+        model.heads.requires_grad_(True)
+
+        return model
+
+To use the model, users need to provide the absolute/relative path to the model definition file, the name of the function, and the keyword arguments to the model function if necessary. For example, to use the ViT model defined above, users should add the following lines to the server configuration file:
+
+.. code-block:: yaml
+    
+    client_configs:
+        ...
+        model_configs:
+            model_path: "<path_to_vit>.py"
+            model_name: "get_vit"
         ...

--- a/examples/requirements.txt
+++ b/examples/requirements.txt
@@ -1,1 +1,0 @@
-appfl[examples] @ git+https://github.com/APPFL/APPFL.git@63810d2350dc51c1f3f64a031f3f1a915e7c13f8#egg=appfl

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ else:
 
 setuptools.setup(
     name="appfl",
-    version="1.0.0",
+    version="1.0.1",
     author=AUTHOR,
     description="An open-source package for privacy-preserving federated learning",
     long_description=long_description,

--- a/src/appfl/agent/client.py
+++ b/src/appfl/agent/client.py
@@ -153,6 +153,8 @@ class ClientAgent:
         - `model_source` and `model_name`: load model from a raw file source string (usually sent from the server)
         - Users can define their own way to load the model from other sources
         """
+        if hasattr(self, "model") and self.model is not None:
+            return
         if not hasattr(self.client_agent_config, "model_configs"):
             self.model = None
             return
@@ -181,6 +183,8 @@ class ClientAgent:
         - `loss_fn`: load commonly-used loss function from `torch.nn` module
         - Users can define their own way to load the loss function from other sources
         """
+        if hasattr(self, "loss_fn") and self.loss_fn is not None:
+            return
         if not hasattr(self.client_agent_config, "train_configs"):
             self.loss_fn = None
             return
@@ -214,6 +218,8 @@ class ClientAgent:
         - `metric_source` and `metric_name`: load metric function from a raw file source string (usually sent from the server)
         - Users can define their own way to load the metric function from other sources
         """
+        if hasattr(self, "metric") and self.metric is not None:
+            return
         if not hasattr(self.client_agent_config, "train_configs"):
             self.metric = None
             return

--- a/src/appfl/agent/client.py
+++ b/src/appfl/agent/client.py
@@ -8,7 +8,7 @@ from appfl.compressor import *
 from appfl.config import ClientAgentConfig
 from appfl.algorithm.trainer import BaseTrainer
 from omegaconf import DictConfig, OmegaConf
-from typing import Union, Dict, OrderedDict, Tuple, Optional, Any
+from typing import Union, Dict, OrderedDict, Tuple, Optional
 from appfl.logger import ClientAgentFileLogger
 from appfl.misc import create_instance_from_file, \
     run_function_from_file, \
@@ -33,13 +33,10 @@ class ClientAgent:
     Users can overwrite any class method to add custom functionalities of the client agent.
     
     :param client_agent_config: configurations for the client agent
-    :param trainer: [Optional] a trainer class for training the model. This is only useful
-        when user uses a custom trainer that is not available in the `appfl.algorithm.trainer` module.
     """
     def __init__(
         self, 
         client_agent_config: ClientAgentConfig = ClientAgentConfig(),
-        trainer: Optional[Any] = None,
         **kwargs
     ) -> None:
         self.client_agent_config = client_agent_config
@@ -48,7 +45,7 @@ class ClientAgent:
         self._load_loss()
         self._load_metric()
         self._load_data()
-        self._load_trainer(trainer)
+        self._load_trainer()
         self._load_compressor()
 
     def load_config(self, config: DictConfig) -> None:
@@ -233,13 +230,51 @@ class ClientAgent:
         else:
             self.metric = None
 
-    def _load_trainer(self, trainer: Optional[Any] = None) -> None:
+    def _load_trainer(self) -> None:
         """Obtain a local trainer"""
         if hasattr(self, "trainer") and self.trainer is not None:
             return
-        if trainer is not None or (getattr(self, "trainer_type", None) is not None):
-            self.trainer_type = trainer if trainer is not None else self.trainer_type
-            self.trainer = self.trainer_type(
+        if not hasattr(self.client_agent_config, "train_configs"):
+            self.trainer = None
+            return
+        if (
+            not hasattr(self.client_agent_config.train_configs, "trainer")
+            and
+            not hasattr(self.client_agent_config.train_configs, "trainer_path")
+            and
+            not hasattr(self.client_agent_config.train_configs, "trainer_source")
+        ):
+            self.trainer = None
+            return
+        if hasattr(self.client_agent_config.train_configs, "trainer_path"):
+            self.trainer = create_instance_from_file(
+                self.client_agent_config.train_configs.trainer_path,
+                self.client_agent_config.train_configs.trainer,
+                model=self.model,
+                loss_fn=self.loss_fn,
+                metric=self.metric,
+                train_dataset=self.train_dataset,
+                val_dataset=self.val_dataset,
+                train_configs=self.client_agent_config.train_configs,
+                logger=self.logger,
+            )
+        elif hasattr(self.client_agent_config.train_configs, "trainer_source"):
+            self.trainer = create_instance_from_file_source(
+                self.client_agent_config.train_configs.trainer_source,
+                self.client_agent_config.train_configs.trainer,
+                model=self.model,
+                loss_fn=self.loss_fn,
+                metric=self.metric,
+                train_dataset=self.train_dataset,
+                val_dataset=self.val_dataset,
+                train_configs=self.client_agent_config.train_configs,
+                logger=self.logger,
+            )
+        else:
+            trainer_module = importlib.import_module('appfl.algorithm.trainer')
+            if not hasattr(trainer_module, self.client_agent_config.train_configs.trainer):
+                raise ValueError(f'Invalid trainer name: {self.client_agent_config.train_configs.trainer}')
+            self.trainer: BaseTrainer = getattr(trainer_module, self.client_agent_config.train_configs.trainer)(
                 model=self.model, 
                 loss_fn=self.loss_fn,
                 metric=self.metric,
@@ -248,25 +283,6 @@ class ClientAgent:
                 train_configs=self.client_agent_config.train_configs,
                 logger=self.logger,
             )
-            return
-        if not hasattr(self.client_agent_config, "train_configs"):
-            self.trainer = None
-            return
-        if not hasattr(self.client_agent_config.train_configs, "trainer"):
-            self.trainer = None
-            return
-        trainer_module = importlib.import_module('appfl.algorithm.trainer')
-        if not hasattr(trainer_module, self.client_agent_config.train_configs.trainer):
-            raise ValueError(f'Invalid trainer name: {self.client_agent_config.train_configs.trainer}')
-        self.trainer: BaseTrainer = getattr(trainer_module, self.client_agent_config.train_configs.trainer)(
-            model=self.model, 
-            loss_fn=self.loss_fn,
-            metric=self.metric,
-            train_dataset=self.train_dataset, 
-            val_dataset=self.val_dataset,
-            train_configs=self.client_agent_config.train_configs,
-            logger=self.logger,
-        )
 
     def _load_compressor(self) -> None:
         """

--- a/src/appfl/agent/server.py
+++ b/src/appfl/agent/server.py
@@ -218,22 +218,25 @@ class ServerAgent:
         Load model from the definition file, and read the source code of the model for sendind to the client.
         User can overwrite this method to load the model from other sources.
         """
-        self._set_seed()
-        model_configs = (
-            self.server_agent_config.client_configs.model_configs 
-            if hasattr(self.server_agent_config.client_configs, "model_configs") 
-            else self.server_agent_config.server_configs.model_configs
-        )
-        self.model = create_instance_from_file(
-            model_configs.model_path,
-            model_configs.model_name,
-            **(model_configs.model_kwargs if hasattr(model_configs, "model_kwargs") else {})
-        )
-        # load the model source file and delete model path
         if hasattr(self.server_agent_config.client_configs, "model_configs"):
-            with open(model_configs.model_path, 'r') as f:
-                self.server_agent_config.client_configs.model_configs.model_source = f.read()
-            del self.server_agent_config.client_configs.model_configs.model_path
+            self._set_seed()
+            model_configs = (
+                self.server_agent_config.client_configs.model_configs 
+                if hasattr(self.server_agent_config.client_configs, "model_configs") 
+                else self.server_agent_config.server_configs.model_configs
+            )
+            self.model = create_instance_from_file(
+                model_configs.model_path,
+                model_configs.model_name,
+                **(model_configs.model_kwargs if hasattr(model_configs, "model_kwargs") else {})
+            )
+            # load the model source file and delete model path
+            if hasattr(self.server_agent_config.client_configs, "model_configs"):
+                with open(model_configs.model_path, 'r') as f:
+                    self.server_agent_config.client_configs.model_configs.model_source = f.read()
+                del self.server_agent_config.client_configs.model_configs.model_path
+        else:
+            self.model = None
 
     def _load_loss(self) -> None:
         """
@@ -315,6 +318,8 @@ class ServerAgent:
         if not self.enable_compression:
             return torch.load(io.BytesIO(model_bytes))
         else:
+            if self.model is None:
+                raise ValueError("Model is not provided to the server, so you cannot use compression.")
             return self.compressor.decompress_model(model_bytes, self.model)
             
     def _load_val_data(self) -> None:

--- a/src/appfl/agent/server.py
+++ b/src/appfl/agent/server.py
@@ -288,7 +288,7 @@ class ServerAgent:
             self.aggregator = create_instance_from_file(
                 self.server_agent_config.server_configs.aggregator_path,
                 self.server_agent_config.server_configs.aggregator,
-                aggregator_config=OmegaConf.create(
+                aggregator_configs=OmegaConf.create(
                     self.server_agent_config.server_configs.aggregator_kwargs if
                     hasattr(self.server_agent_config.server_configs, "aggregator_kwargs") else {}
                 ),

--- a/src/appfl/algorithm/aggregator/fedadagrad_aggregator.py
+++ b/src/appfl/algorithm/aggregator/fedadagrad_aggregator.py
@@ -9,7 +9,7 @@ class FedAdagradAggregator(FedAvgAggregator):
     For more details, check paper `Adaptive Federated Optimization`
     at https://arxiv.org/pdf/2003.00295.pdf
 
-    Required aggregator_config fields:
+    Required aggregator_configs fields:
         - server_learning_rate: `eta` in the paper
         - server_adapt_param: `tau` in the paper
         - server_momentum_param_1: `beta_1` in the paper
@@ -17,10 +17,10 @@ class FedAdagradAggregator(FedAvgAggregator):
     def __init__(
         self,
         model: Optional[torch.nn.Module] = None,
-        aggregator_config: DictConfig = DictConfig({}),
+        aggregator_configs: DictConfig = DictConfig({}),
         logger: Optional[Any] = None
     ):
-        super().__init__(model, aggregator_config, logger)
+        super().__init__(model, aggregator_configs, logger)
         self.m_vector = {}
         self.v_vector = {}
     
@@ -32,15 +32,15 @@ class FedAdagradAggregator(FedAvgAggregator):
         if len(self.m_vector) == 0:
             for name in self.step:
                 self.m_vector[name] = torch.zeros_like(self.step[name])
-                self.v_vector[name] = torch.zeros_like(self.step[name]) + self.aggregator_config.server_adapt_param**2
+                self.v_vector[name] = torch.zeros_like(self.step[name]) + self.aggregator_configs.server_adapt_param**2
 
         for name in self.step:
             self.m_vector[name] = (
-                self.aggregator_config.server_momentum_param_1 * self.m_vector[name] + 
-                (1-self.aggregator_config.server_momentum_param_1) * self.step[name]
+                self.aggregator_configs.server_momentum_param_1 * self.m_vector[name] + 
+                (1-self.aggregator_configs.server_momentum_param_1) * self.step[name]
             )
             self.v_vector[name] += torch.square(self.step[name])
             self.step[name] = torch.div(
-                self.aggregator_config.server_learning_rate * self.m_vector[name],
-                torch.sqrt(self.v_vector[name]) + self.aggregator_config.server_adapt_param
+                self.aggregator_configs.server_learning_rate * self.m_vector[name],
+                torch.sqrt(self.v_vector[name]) + self.aggregator_configs.server_adapt_param
             )

--- a/src/appfl/algorithm/aggregator/fedadagrad_aggregator.py
+++ b/src/appfl/algorithm/aggregator/fedadagrad_aggregator.py
@@ -1,7 +1,7 @@
 import torch
 from omegaconf import DictConfig
-from typing import Union, Dict, OrderedDict, Any
 from appfl.algorithm.aggregator import FedAvgAggregator
+from typing import Union, Dict, OrderedDict, Any, Optional
 
 class FedAdagradAggregator(FedAvgAggregator):
     """
@@ -16,23 +16,25 @@ class FedAdagradAggregator(FedAvgAggregator):
     """
     def __init__(
         self,
-        model: torch.nn.Module,
-        aggregator_config: DictConfig,
-        logger: Any
+        model: Optional[torch.nn.Module] = None,
+        aggregator_config: DictConfig = DictConfig({}),
+        logger: Optional[Any] = None
     ):
         super().__init__(model, aggregator_config, logger)
         self.m_vector = {}
         self.v_vector = {}
-        for name in self.named_parameters:
-            self.m_vector[name] = torch.zeros_like(self.model.state_dict()[name])
-            self.v_vector[name] = torch.zeros_like(self.model.state_dict()[name]) + self.aggregator_config.server_adapt_param**2
     
     def compute_steps(self, local_models: Dict[Union[str, int], Union[Dict, OrderedDict]]):
         """
         Compute the changes to the global model after the aggregation.
         """
         super().compute_steps(local_models)
-        for name in self.named_parameters:
+        if len(self.m_vector) == 0:
+            for name in self.step:
+                self.m_vector[name] = torch.zeros_like(self.step[name])
+                self.v_vector[name] = torch.zeros_like(self.step[name]) + self.aggregator_config.server_adapt_param**2
+
+        for name in self.step:
             self.m_vector[name] = (
                 self.aggregator_config.server_momentum_param_1 * self.m_vector[name] + 
                 (1-self.aggregator_config.server_momentum_param_1) * self.step[name]

--- a/src/appfl/algorithm/aggregator/fedadam_aggregator.py
+++ b/src/appfl/algorithm/aggregator/fedadam_aggregator.py
@@ -9,7 +9,7 @@ class FedAdamAggregator(FedAvgAggregator):
     For more details, check paper `Adaptive Federated Optimization`
     at https://arxiv.org/pdf/2003.00295.pdf
 
-    Required aggregator_config fields:
+    Required aggregator_configs fields:
         - server_learning_rate: `eta` in the paper
         - server_adapt_param: `tau` in the paper
         - server_momentum_param_1: `beta_1` in the paper
@@ -18,10 +18,10 @@ class FedAdamAggregator(FedAvgAggregator):
     def __init__(
         self,
         model: Optional[torch.nn.Module] = None,
-        aggregator_config: DictConfig = DictConfig({}),
+        aggregator_configs: DictConfig = DictConfig({}),
         logger: Optional[Any] = None
     ):
-        super().__init__(model, aggregator_config, logger)
+        super().__init__(model, aggregator_configs, logger)
         self.m_vector = {}
         self.v_vector = {}
     
@@ -33,18 +33,18 @@ class FedAdamAggregator(FedAvgAggregator):
         if len(self.m_vector) == 0:
             for name in self.step:
                 self.m_vector[name] = torch.zeros_like(self.step[name])
-                self.v_vector[name] = torch.zeros_like(self.step[name]) + self.aggregator_config.server_adapt_param**2
+                self.v_vector[name] = torch.zeros_like(self.step[name]) + self.aggregator_configs.server_adapt_param**2
         
         for name in self.step:
             self.m_vector[name] = (
-                self.aggregator_config.server_momentum_param_1 * self.m_vector[name] + 
-                (1-self.aggregator_config.server_momentum_param_1) * self.step[name]
+                self.aggregator_configs.server_momentum_param_1 * self.m_vector[name] + 
+                (1-self.aggregator_configs.server_momentum_param_1) * self.step[name]
             )
             self.v_vector[name] = (
-                self.aggregator_config.server_momentum_param_2 * self.v_vector[name] + 
-                (1-self.aggregator_config.server_momentum_param_2) * torch.square(self.step[name])
+                self.aggregator_configs.server_momentum_param_2 * self.v_vector[name] + 
+                (1-self.aggregator_configs.server_momentum_param_2) * torch.square(self.step[name])
             )
             self.step[name] = torch.div(
-                self.aggregator_config.server_learning_rate * self.m_vector[name],
-                torch.sqrt(self.v_vector[name]) + self.aggregator_config.server_adapt_param
+                self.aggregator_configs.server_learning_rate * self.m_vector[name],
+                torch.sqrt(self.v_vector[name]) + self.aggregator_configs.server_adapt_param
             )

--- a/src/appfl/algorithm/aggregator/fedadam_aggregator.py
+++ b/src/appfl/algorithm/aggregator/fedadam_aggregator.py
@@ -1,7 +1,7 @@
 import torch
 from omegaconf import DictConfig
-from typing import Union, Dict, OrderedDict, Any
 from appfl.algorithm.aggregator import FedAvgAggregator
+from typing import Union, Dict, OrderedDict, Any, Optional
 
 class FedAdamAggregator(FedAvgAggregator):
     """
@@ -17,23 +17,25 @@ class FedAdamAggregator(FedAvgAggregator):
     """
     def __init__(
         self,
-        model: torch.nn.Module,
-        aggregator_config: DictConfig,
-        logger: Any
+        model: Optional[torch.nn.Module] = None,
+        aggregator_config: DictConfig = DictConfig({}),
+        logger: Optional[Any] = None
     ):
         super().__init__(model, aggregator_config, logger)
         self.m_vector = {}
         self.v_vector = {}
-        for name in self.named_parameters:
-            self.m_vector[name] = torch.zeros_like(self.model.state_dict()[name])
-            self.v_vector[name] = torch.zeros_like(self.model.state_dict()[name]) + self.aggregator_config.server_adapt_param**2
     
     def compute_steps(self, local_models: Dict[Union[str, int], Union[Dict, OrderedDict]]):
         """
         Compute the changes to the global model after the aggregation.
         """
         super().compute_steps(local_models)
-        for name in self.named_parameters:
+        if len(self.m_vector) == 0:
+            for name in self.step:
+                self.m_vector[name] = torch.zeros_like(self.step[name])
+                self.v_vector[name] = torch.zeros_like(self.step[name]) + self.aggregator_config.server_adapt_param**2
+        
+        for name in self.step:
             self.m_vector[name] = (
                 self.aggregator_config.server_momentum_param_1 * self.m_vector[name] + 
                 (1-self.aggregator_config.server_momentum_param_1) * self.step[name]

--- a/src/appfl/algorithm/aggregator/fedavg_aggregator.py
+++ b/src/appfl/algorithm/aggregator/fedavg_aggregator.py
@@ -10,20 +10,20 @@ class FedAvgAggregator(BaseAggregator):
         This can be useful for aggregating parameters that does requires gradient, such as the batch
         normalization layers. If not provided, the aggregator will only aggregate the parameters 
         sent by the clients.
-    :param `aggregator_config`: Configuration for the aggregator. It should be specified in the YAML
+    :param `aggregator_configs`: Configuration for the aggregator. It should be specified in the YAML
         configuration file under `aggregator_kwargs`.
     :param `logger`: An optional instance of the logger to be used for logging.
     """
     def __init__(
         self,
         model: Optional[torch.nn.Module] = None,
-        aggregator_config: DictConfig = DictConfig({}),
+        aggregator_configs: DictConfig = DictConfig({}),
         logger: Optional[Any] = None
     ):
         self.model = model
         self.logger = logger
-        self.aggregator_config = aggregator_config
-        self.client_weights_mode = aggregator_config.get("client_weights_mode", "equal")
+        self.aggregator_configs = aggregator_configs
+        self.client_weights_mode = aggregator_configs.get("client_weights_mode", "equal")
 
         if self.model is not None:
             self.named_parameters = set()

--- a/src/appfl/algorithm/aggregator/fedavg_aggregator.py
+++ b/src/appfl/algorithm/aggregator/fedavg_aggregator.py
@@ -1,56 +1,91 @@
 import copy
 import torch
 from omegaconf import DictConfig
-from typing import Union, Dict, OrderedDict, Any
 from appfl.algorithm.aggregator import BaseAggregator
+from typing import Union, Dict, OrderedDict, Any, Optional
 
 class FedAvgAggregator(BaseAggregator):
+    """
+    :param `model`: An optional instance of the model to be trained in the federated learning setup.
+        This can be useful for aggregating parameters that does requires gradient, such as the batch
+        normalization layers. If not provided, the aggregator will only aggregate the parameters 
+        sent by the clients.
+    :param `aggregator_config`: Configuration for the aggregator. It should be specified in the YAML
+        configuration file under `aggregator_kwargs`.
+    :param `logger`: An optional instance of the logger to be used for logging.
+    """
     def __init__(
         self,
-        model: torch.nn.Module,
-        aggregator_config: DictConfig,
-        logger: Any
+        model: Optional[torch.nn.Module] = None,
+        aggregator_config: DictConfig = DictConfig({}),
+        logger: Optional[Any] = None
     ):
         self.model = model
         self.logger = logger
         self.aggregator_config = aggregator_config
         self.client_weights_mode = aggregator_config.get("client_weights_mode", "equal")
 
-        self.named_parameters = set()
-        for name, _ in self.model.named_parameters():
-            self.named_parameters.add(name)
+        if self.model is not None:
+            self.named_parameters = set()
+            for name, _ in self.model.named_parameters():
+                self.named_parameters.add(name)
+        else:
+            self.named_parameters = None
+
+        self.global_state = None # Models parameters that are used for aggregation, this is unknown at the beginning
 
         self.step = {}
 
     def get_parameters(self, **kwargs) -> Dict:
-        return copy.deepcopy(self.model.state_dict())
+        """
+        The aggregator can deal with three general aggregation cases:
+        
+        - The model is provided to the aggregator and it has the same state as the global state 
+        [**Note**: By global state, it means the state of the model that is used for aggregation]:
+            In this case, the aggregator will always return the global state of the model.
+        - The model is provided to the aggregator, but it has a different global state (e.g., part of the model is shared for aggregation):
+            In this case, the aggregator will return the whole state of the model at the beginning (i.e., when it does not have the global state),
+            and return the global state afterward.
+        - The model is not provided to the aggregator:
+            In this case, the aggregator will raise an error when it does not have the global state (i.e., at the beginning), and return the global state afterward.
+        """
+        if self.global_state is None:
+            if self.model is not None:
+                return copy.deepcopy(self.model.state_dict())
+            else:
+                raise ValueError("Model is not provided to the aggregator.")
+        return copy.deepcopy(self.global_state)
 
     def aggregate(self, local_models: Dict[Union[str, int], Union[Dict, OrderedDict]], **kwargs) -> Dict:
         """
         Take the weighted average of local models from clients and return the global model.
         """
-        global_state = copy.deepcopy(self.model.state_dict())
+        if self.global_state is None:
+            self.global_state = copy.deepcopy(list(local_models.values())[0]) # Set the global state to the same state as the first client
         
         self.compute_steps(local_models)
         
-        for name in self.model.state_dict():
-            if name not in self.named_parameters:
-                param_sum = torch.zeros_like(self.model.state_dict()[name])
+        for name in self.global_state:
+            if name in self.step:
+                self.global_state[name] += self.step[name]
+            else:
+                param_sum = torch.zeros_like(self.global_state[name])
                 for _, model in local_models.items():
                     param_sum += model[name]
-                global_state[name] = torch.div(param_sum, len(local_models))
-            else:
-                global_state[name] += self.step[name]
-            
-        self.model.load_state_dict(global_state)
-        return global_state
+                self.global_state[name] = torch.div(param_sum, len(local_models))
+        if self.model is not None:
+            self.model.load_state_dict(self.global_state, strict=False)
+        return copy.deepcopy(self.global_state)
     
     def compute_steps(self, local_models: Dict[Union[str, int], Union[Dict, OrderedDict]]):
         """
         Compute the changes to the global model after the aggregation.
-        """
-        for name in self.named_parameters:
-            self.step[name] = torch.zeros_like(self.model.state_dict()[name])
+        """ 
+        for name in self.global_state:
+            if self.named_parameters is not None and name not in self.named_parameters:
+                continue
+            self.step[name] = torch.zeros_like(self.global_state[name])
+        
         for client_id, model in local_models.items():
             if (
                 self.client_weights_mode == "sample_size" and
@@ -60,7 +95,7 @@ class FedAvgAggregator(BaseAggregator):
                 weight = self.client_sample_size[client_id] / sum(self.client_sample_size.values())
             else:
                 weight = 1.0 / len(local_models)
-            for name in self.named_parameters:
-                self.step[name] += weight * (model[name] - self.model.state_dict()[name])
-    
-
+                
+            for name in model:
+                if name in self.step:
+                    self.step[name] += weight * (model[name] - self.global_state[name])

--- a/src/appfl/algorithm/aggregator/fedavgm_aggregator.py
+++ b/src/appfl/algorithm/aggregator/fedavgm_aggregator.py
@@ -9,16 +9,16 @@ class FedAvgMAggregator(FedAvgAggregator):
     For more details, check paper `Measuring the effects of non-identical data distribution for federated visual classification`
     at https://arxiv.org/pdf/1909.06335.pdf
 
-    Required aggregator_config fields:
+    Required aggregator_configs fields:
         - server_momentum_param_1: `beta` in the paper
     """
     def __init__(
         self,
         model: Optional[torch.nn.Module] = None,
-        aggregator_config: DictConfig = DictConfig({}),
+        aggregator_configs: DictConfig = DictConfig({}),
         logger: Optional[Any] = None
     ):
-        super().__init__(model, aggregator_config, logger)
+        super().__init__(model, aggregator_configs, logger)
         self.v_vector = {}
     
     def compute_steps(self, local_models: Dict[Union[str, int], Union[Dict, OrderedDict]]):
@@ -31,5 +31,5 @@ class FedAvgMAggregator(FedAvgAggregator):
                 self.v_vector[name] = torch.zeros_like(self.step[name])
         
         for name in self.step:
-            self.v_vector[name] = self.aggregator_config.server_momentum_param_1 * self.v_vector[name] + self.step[name]
+            self.v_vector[name] = self.aggregator_configs.server_momentum_param_1 * self.v_vector[name] + self.step[name]
             self.step[name] = self.v_vector[name]

--- a/src/appfl/algorithm/aggregator/fedbuff_aggregator.py
+++ b/src/appfl/algorithm/aggregator/fedbuff_aggregator.py
@@ -12,12 +12,12 @@ class FedBuffAggregator(FedAsyncAggregator):
     def __init__(
         self,
         model: Optional[torch.nn.Module] = None,
-        aggregator_config: DictConfig = DictConfig({}),
+        aggregator_configs: DictConfig = DictConfig({}),
         logger: Optional[Any] = None
     ):
-        super().__init__(model, aggregator_config, logger)
+        super().__init__(model, aggregator_configs, logger)
         self.buff_size = 0
-        self.K = self.aggregator_config.K
+        self.K = self.aggregator_configs.K
 
     def aggregate(self, client_id: Union[str, int], local_model: Union[Dict, OrderedDict], **kwargs) -> Dict:
         if self.global_state is None:
@@ -56,7 +56,7 @@ class FedBuffAggregator(FedAsyncAggregator):
         
         if client_id not in self.client_step:
             self.client_step[client_id] = 0
-        gradient_based = self.aggregator_config.get("gradient_based", False)
+        gradient_based = self.aggregator_configs.get("gradient_based", False)
         if (
             self.client_weights_mode == "sample_size" and
             hasattr(self, "client_sample_size") and
@@ -64,7 +64,7 @@ class FedBuffAggregator(FedAsyncAggregator):
         ):
             weight = self.client_sample_size[client_id] / sum(self.client_sample_size.values())
         else:
-            weight = 1.0 / self.aggregator_config.get("num_clients", 1)
+            weight = 1.0 / self.aggregator_configs.get("num_clients", 1)
         alpha_t = self.alpha * self.staleness_fn(self.global_step - self.client_step[client_id]) * weight
 
         for name in self.global_state:

--- a/src/appfl/algorithm/aggregator/fedbuff_aggregator.py
+++ b/src/appfl/algorithm/aggregator/fedbuff_aggregator.py
@@ -1,8 +1,8 @@
 import copy
 import torch
 from omegaconf import DictConfig
-from typing import Union, Dict, OrderedDict, Any
 from appfl.algorithm.aggregator import FedAsyncAggregator
+from typing import Union, Dict, OrderedDict, Any, Optional
 
 class FedBuffAggregator(FedAsyncAggregator):
     """
@@ -11,39 +11,48 @@ class FedBuffAggregator(FedAsyncAggregator):
     """
     def __init__(
         self,
-        model: torch.nn.Module,
-        aggregator_config: DictConfig,
-        logger: Any
+        model: Optional[torch.nn.Module] = None,
+        aggregator_config: DictConfig = DictConfig({}),
+        logger: Optional[Any] = None
     ):
         super().__init__(model, aggregator_config, logger)
         self.buff_size = 0
         self.K = self.aggregator_config.K
 
     def aggregate(self, client_id: Union[str, int], local_model: Union[Dict, OrderedDict], **kwargs) -> Dict:
-        global_state = copy.deepcopy(self.model.state_dict())
+        if self.global_state is None:
+            if self.model is not None:
+                self.global_state = {
+                    name: self.model.state_dict()[name] for name in local_model
+                }
+            else:
+                self.global_state = copy.deepcopy(local_model)
         
         self.compute_steps(client_id, local_model)
         self.buff_size += 1
         if self.buff_size == self.K:
-            for name in self.model.state_dict():
-                if name not in self.named_parameters:
-                    global_state[name] = torch.div(self.step[name], self.K)
+            for name in self.global_state:
+                if self.named_parameters is not None and name not in self.named_parameters:
+                    self.global_state[name] = torch.div(self.step[name], self.K)
                 else:
-                    global_state[name] += self.step[name]
-            self.model.load_state_dict(global_state)
+                    self.global_state[name] += self.step[name]
+            
             self.global_step += 1
             self.buff_size = 0
             
+            if self.model is not None:
+                self.model.load_state_dict(self.global_state, strict=False)
+                
         self.client_step[client_id] = self.global_step
-        return global_state
+        return copy.deepcopy(self.global_state)
     
     def compute_steps(self, client_id: Union[str, int], local_model: Union[Dict, OrderedDict],):
         """
         Compute changes to the global model after the aggregation.
         """
         if self.buff_size == 0:
-            for name in self.model.state_dict():
-                self.step[name] = torch.zeros_like(self.model.state_dict()[name])
+            for name in self.global_state:
+                self.step[name] = torch.zeros_like(self.global_state[name])
         
         if client_id not in self.client_step:
             self.client_step[client_id] = 0
@@ -58,11 +67,11 @@ class FedBuffAggregator(FedAsyncAggregator):
             weight = 1.0 / self.aggregator_config.get("num_clients", 1)
         alpha_t = self.alpha * self.staleness_fn(self.global_step - self.client_step[client_id]) * weight
 
-        for name in self.model.state_dict():
-            if name in self.named_parameters:
+        for name in self.global_state:
+            if self.named_parameters is not None and name not in self.named_parameters:
+                self.step[name] += local_model[name]
+            else:
                 self.step[name] += (
                     alpha_t * (-local_model[name]) if gradient_based
-                    else alpha_t * (local_model[name] - self.model.state_dict()[name])
+                    else alpha_t * (local_model[name] - self.global_state[name])
                 )
-            else:
-                self.step[name] += local_model[name]

--- a/src/appfl/algorithm/aggregator/fedcompass_aggregator.py
+++ b/src/appfl/algorithm/aggregator/fedcompass_aggregator.py
@@ -12,17 +12,17 @@ class FedCompassAggregator(BaseAggregator):
     def __init__(
         self,
         model: Optional[torch.nn.Module] = None,
-        aggregator_config: DictConfig = DictConfig({}),
+        aggregator_configs: DictConfig = DictConfig({}),
         logger: Optional[Any] = None
     ):
         self.model = model
         self.logger = logger
-        self.aggregator_config = aggregator_config
+        self.aggregator_configs = aggregator_configs
         self.staleness_fn = self.__staleness_fn_factory(
-            staleness_fn_name= self.aggregator_config.get("staleness_fn", "constant"),
-            **self.aggregator_config.get("staleness_fn_kwargs", {})
+            staleness_fn_name= self.aggregator_configs.get("staleness_fn", "constant"),
+            **self.aggregator_configs.get("staleness_fn_kwargs", {})
         )
-        self.alpha = self.aggregator_config.get("alpha", 0.9)
+        self.alpha = self.aggregator_configs.get("alpha", 0.9)
         
         self.global_state = None # Models parameters that are used for aggregation, this is unknown at the beginning
 
@@ -57,9 +57,9 @@ class FedCompassAggregator(BaseAggregator):
                 else:
                     self.global_state = copy.deepcopy(list(local_models.values())[0])
 
-        gradient_based = self.aggregator_config.get("gradient_based", False)
+        gradient_based = self.aggregator_configs.get("gradient_based", False)
         if client_id is not None and local_model is not None:
-            weight = 1.0 / self.aggregator_config.get("num_clients", 1)
+            weight = 1.0 / self.aggregator_configs.get("num_clients", 1)
             alpha_t = self.alpha * self.staleness_fn(staleness) * weight
             
             for name in self.global_state:
@@ -74,7 +74,7 @@ class FedCompassAggregator(BaseAggregator):
         else:
             for i, client_id in enumerate(local_models):
                 local_model = local_models[client_id]
-                weight = 1.0 / self.aggregator_config.get("num_clients", 1)
+                weight = 1.0 / self.aggregator_configs.get("num_clients", 1)
                 alpha_t = self.alpha * self.staleness_fn(staleness[client_id]) * weight
                 for name in self.global_state:
                     if self.named_parameters is not None and name not in self.named_parameters:

--- a/src/appfl/algorithm/aggregator/fedcompass_aggregator.py
+++ b/src/appfl/algorithm/aggregator/fedcompass_aggregator.py
@@ -1,8 +1,8 @@
 import copy
 import torch
 from omegaconf import DictConfig
-from typing import Union, Dict, OrderedDict, Any, Optional
 from appfl.algorithm.aggregator import BaseAggregator
+from typing import Union, Dict, OrderedDict, Any, Optional
 
 class FedCompassAggregator(BaseAggregator):
     """
@@ -11,9 +11,9 @@ class FedCompassAggregator(BaseAggregator):
     """
     def __init__(
         self,
-        model: torch.nn.Module,
-        aggregator_config: DictConfig,
-        logger: Any
+        model: Optional[torch.nn.Module] = None,
+        aggregator_config: DictConfig = DictConfig({}),
+        logger: Optional[Any] = None
     ):
         self.model = model
         self.logger = logger
@@ -23,10 +23,15 @@ class FedCompassAggregator(BaseAggregator):
             **self.aggregator_config.get("staleness_fn_kwargs", {})
         )
         self.alpha = self.aggregator_config.get("alpha", 0.9)
+        
+        self.global_state = None # Models parameters that are used for aggregation, this is unknown at the beginning
 
-        self.named_parameters = set()
-        for name, _ in self.model.named_parameters():
-            self.named_parameters.add(name)
+        if model is not None:
+            self.named_parameters = set()
+            for name, _ in self.model.named_parameters():
+                self.named_parameters.add(name)
+        else:
+            self.named_parameters = None
 
     def aggregate(
             self,
@@ -36,41 +41,77 @@ class FedCompassAggregator(BaseAggregator):
             staleness: Optional[Union[int, Dict[Union[str, int], int]]] = None,
             **kwargs
         ) -> Dict:
-        global_state = copy.deepcopy(self.model.state_dict())
+        if self.global_state is None:
+            if client_id is not None and local_model is not None:
+                if self.model is not None:
+                    self.global_state = {
+                        name: self.model.state_dict()[name] for name in local_model
+                    }
+                else:
+                    self.global_state = copy.deepcopy(local_model)
+            else:
+                if self.model is not None:
+                    self.global_state = {
+                        name: self.model.state_dict()[name] for name in list(local_models.values())[0]
+                    }
+                else:
+                    self.global_state = copy.deepcopy(list(local_models.values())[0])
+
         gradient_based = self.aggregator_config.get("gradient_based", False)
         if client_id is not None and local_model is not None:
             weight = 1.0 / self.aggregator_config.get("num_clients", 1)
             alpha_t = self.alpha * self.staleness_fn(staleness) * weight
-            for name in self.model.state_dict():
-                if name in self.named_parameters:
-                    if gradient_based:
-                        global_state[name] -= local_model[name] * alpha_t
-                    else:
-                        global_state[name] -= (global_state[name] - local_model[name]) * alpha_t
+            
+            for name in self.global_state:
+                if self.named_parameters is not None and name not in self.named_parameters:
+                    self.global_state[name] = local_model[name]
                 else:
-                    global_state[name] = local_model[name]
+                    if gradient_based:
+                        self.global_state[name] -= local_model[name] * alpha_t
+                    else:
+                        self.global_state[name] -= (self.global_state[name] - local_model[name]) * alpha_t
+                        
         else:
             for i, client_id in enumerate(local_models):
                 local_model = local_models[client_id]
                 weight = 1.0 / self.aggregator_config.get("num_clients", 1)
                 alpha_t = self.alpha * self.staleness_fn(staleness[client_id]) * weight
-                for name in self.model.state_dict():
-                    if name in self.named_parameters:
-                        if gradient_based:
-                            global_state[name] -= local_model[name] * alpha_t
-                        else:
-                            global_state[name] -= (self.model.state_dict()[name] - local_model[name]) * alpha_t
-                    else:
+                for name in self.global_state:
+                    if self.named_parameters is not None and name not in self.named_parameters:
                         if i == 0:
-                            global_state[name] = torch.zeros_like(self.model.state_dict()[name])
-                        global_state[name] += local_model[name]
+                            self.global_state[name] = torch.zeros_like(local_model[name])
+                        self.global_state[name] += local_model[name]
                         if i == len(local_models) - 1:
-                            global_state[name] = torch.div(global_state[name], len(local_models))
-        self.model.load_state_dict(global_state)
-        return global_state
+                            self.global_state[name] = torch.div(self.global_state[name], len(local_models))
+                    else:
+                        if gradient_based:
+                            self.global_state[name] -= local_model[name] * alpha_t
+                        else:
+                            self.global_state[name] -= (self.global_state[name] - local_model[name]) * alpha_t
+                    
+        if self.model is not None:
+            self.model.load_state_dict(self.global_state, strict=False)
+        return copy.deepcopy(self.global_state)
 
     def get_parameters(self, **kwargs) -> Dict:
-        return copy.deepcopy(self.model.state_dict())
+        """
+        The aggregator can deal with three general aggregation cases:
+        
+        - The model is provided to the aggregator and it has the same state as the global state 
+        [**Note**: By global state, it means the state of the model that is used for aggregation]:
+            In this case, the aggregator will always return the global state of the model.
+        - The model is provided to the aggregator, but it has a different global state (e.g., part of the model is shared for aggregation):
+            In this case, the aggregator will return the whole state of the model at the beginning (i.e., when it does not have the global state),
+            and return the global state afterward.
+        - The model is not provided to the aggregator:
+            In this case, the aggregator will raise an error when it does not have the global state (i.e., at the beginning), and return the global state afterward.
+        """
+        if self.global_state is None:
+            if self.model is not None:
+                return copy.deepcopy(self.model.state_dict())
+            else:
+                raise ValueError("Model is not provided to the aggregator.")
+        return copy.deepcopy(self.global_state)
 
     def __staleness_fn_factory(self, staleness_fn_name, **kwargs):
         if staleness_fn_name   == "constant":

--- a/src/appfl/algorithm/aggregator/fedyogi_aggregator.py
+++ b/src/appfl/algorithm/aggregator/fedyogi_aggregator.py
@@ -9,7 +9,7 @@ class FedYogiAggregator(FedAvgAggregator):
     For more details, check paper `Adaptive Federated Optimization`
     at https://arxiv.org/pdf/2003.00295.pdf
 
-    Required aggregator_config fields:
+    Required aggregator_configs fields:
         - server_learning_rate: `eta` in the paper
         - server_adapt_param: `tau` in the paper
         - server_momentum_param_1: `beta_1` in the paper
@@ -18,10 +18,10 @@ class FedYogiAggregator(FedAvgAggregator):
     def __init__(
         self,
         model: Optional[torch.nn.Module] = None,
-        aggregator_config: DictConfig = DictConfig({}),
+        aggregator_configs: DictConfig = DictConfig({}),
         logger: Optional[Any] = None
     ):
-        super().__init__(model, aggregator_config, logger)
+        super().__init__(model, aggregator_configs, logger)
         self.m_vector = {}
         self.v_vector = {}
     
@@ -33,18 +33,18 @@ class FedYogiAggregator(FedAvgAggregator):
         if len(self.m_vector) == 0:
             for name in self.step:
                 self.m_vector[name] = torch.zeros_like(self.step[name])
-                self.v_vector[name] = torch.zeros_like(self.step[name]) + self.aggregator_config.server_adapt_param**2
+                self.v_vector[name] = torch.zeros_like(self.step[name]) + self.aggregator_configs.server_adapt_param**2
 
         for name in self.step:
             self.m_vector[name] = (
-                self.aggregator_config.server_momentum_param_1 * self.m_vector[name] + 
-                (1-self.aggregator_config.server_momentum_param_1) * self.step[name]
+                self.aggregator_configs.server_momentum_param_1 * self.m_vector[name] + 
+                (1-self.aggregator_configs.server_momentum_param_1) * self.step[name]
             )
-            self.v_vector[name] -= (1-self.aggregator_config.server_momentum_param_2) * torch.mul(
+            self.v_vector[name] -= (1-self.aggregator_configs.server_momentum_param_2) * torch.mul(
                 torch.square(self.step[name]),
                 torch.sign(self.v_vector[name] - torch.square(self.step[name]))
             )
             self.step[name] = torch.div(
-                self.aggregator_config.server_learning_rate * self.m_vector[name],
-                torch.sqrt(self.v_vector[name]) + self.aggregator_config.server_adapt_param
+                self.aggregator_configs.server_learning_rate * self.m_vector[name],
+                torch.sqrt(self.v_vector[name]) + self.aggregator_configs.server_adapt_param
             )

--- a/src/appfl/algorithm/aggregator/fedyogi_aggregator.py
+++ b/src/appfl/algorithm/aggregator/fedyogi_aggregator.py
@@ -1,7 +1,7 @@
 import torch
 from omegaconf import DictConfig
-from typing import Union, Dict, OrderedDict, Any
 from appfl.algorithm.aggregator import FedAvgAggregator
+from typing import Union, Dict, OrderedDict, Any, Optional
 
 class FedYogiAggregator(FedAvgAggregator):
     """
@@ -17,23 +17,25 @@ class FedYogiAggregator(FedAvgAggregator):
     """
     def __init__(
         self,
-        model: torch.nn.Module,
-        aggregator_config: DictConfig,
-        logger: Any
+        model: Optional[torch.nn.Module] = None,
+        aggregator_config: DictConfig = DictConfig({}),
+        logger: Optional[Any] = None
     ):
         super().__init__(model, aggregator_config, logger)
         self.m_vector = {}
         self.v_vector = {}
-        for name in self.named_parameters:
-            self.m_vector[name] = torch.zeros_like(self.model.state_dict()[name])
-            self.v_vector[name] = torch.zeros_like(self.model.state_dict()[name]) + self.aggregator_config.server_adapt_param**2
     
     def compute_steps(self, local_models: Dict[Union[str, int], Union[Dict, OrderedDict]]):
         """
         Compute the changes to the global model after the aggregation.
         """
         super().compute_steps(local_models)
-        for name in self.named_parameters:
+        if len(self.m_vector) == 0:
+            for name in self.step:
+                self.m_vector[name] = torch.zeros_like(self.step[name])
+                self.v_vector[name] = torch.zeros_like(self.step[name]) + self.aggregator_config.server_adapt_param**2
+
+        for name in self.step:
             self.m_vector[name] = (
                 self.aggregator_config.server_momentum_param_1 * self.m_vector[name] + 
                 (1-self.aggregator_config.server_momentum_param_1) * self.step[name]

--- a/src/appfl/algorithm/aggregator/iceadmm_aggregator.py
+++ b/src/appfl/algorithm/aggregator/iceadmm_aggregator.py
@@ -15,12 +15,12 @@ class ICEADMMAggregator(BaseAggregator):
     def __init__(
         self,
         model: nn.Module,
-        aggregator_config: DictConfig,
+        aggregator_configs: DictConfig,
         logger: Any,
     ):
         self.model = model
         self.logger = logger
-        self.aggregator_config = aggregator_config
+        self.aggregator_configs = aggregator_configs
         self.named_parameters = set()
         for name, _ in self.model.named_parameters():
             self.named_parameters.add(name)
@@ -33,7 +33,7 @@ class ICEADMMAggregator(BaseAggregator):
         self.dual_states = OrderedDict()
         self.primal_states_curr = OrderedDict()
         self.primal_states_prev = OrderedDict()
-        self.device = self.aggregator_config.device if "device" in self.aggregator_config else "cpu"
+        self.device = self.aggregator_configs.device if "device" in self.aggregator_configs else "cpu"
 
     def aggregate(
         self,

--- a/src/appfl/algorithm/aggregator/iiadmm_aggregator.py
+++ b/src/appfl/algorithm/aggregator/iiadmm_aggregator.py
@@ -15,12 +15,12 @@ class IIADMMAggregator(BaseAggregator):
     def __init__(
         self,
         model: nn.Module,
-        aggregator_config: DictConfig,
+        aggregator_configs: DictConfig,
         logger: Any,
     ):
         self.model = model
         self.logger = logger
-        self.aggregator_config = aggregator_config
+        self.aggregator_configs = aggregator_configs
         self.named_parameters = set()
         for name, _ in self.model.named_parameters():
             self.named_parameters.add(name)
@@ -33,7 +33,7 @@ class IIADMMAggregator(BaseAggregator):
         self.dual_states = OrderedDict()
         self.primal_states_curr = OrderedDict()
         self.primal_states_prev = OrderedDict()
-        self.device = self.aggregator_config.device if "device" in self.aggregator_config else "cpu"
+        self.device = self.aggregator_configs.device if "device" in self.aggregator_configs else "cpu"
 
     def aggregate(
         self,

--- a/src/appfl/algorithm/scheduler/compass_scheduler.py
+++ b/src/appfl/algorithm/scheduler/compass_scheduler.py
@@ -33,6 +33,7 @@ class CompassScheduler(BaseScheduler):
         self._num_global_epochs = 0
         self._access_lock = threading.Lock() # handle client requests as a queue
         self._timer_record = {}
+        self.start_time = time.time() 
         super().__init__(scheduler_configs, aggregator, logger)
 
     def get_parameters(self, **kwargs) -> Union[Future, Dict, OrderedDict, Tuple[Union[Dict, OrderedDict], Dict]]:


### PR DESCRIPTION
## Changelog
- For the aggregators, the model architecture is set to be an optional initialization parameter, and the aggregators only aggregate the parameters sent by the clients instead of the whole set of model parameters. This is useful when doing federated fine-tuning or federated transfer learning where only part of model parameters are updated / the model architecture is unknown to the aggregator.
- Support easy integration of custom trainer/aggregator: user only needs to provide the custom trainer/aggregator class name and the path to the definition file in the configuration file to use it, instead of modifying the source code.
- Add a detailed step-by-step tutorial on how to use ``APPFL`` to fine-tune a ViT model with a custom trainer.
## Detailed explanations
This PR comes from a case study that uses `APPFL` to fine-tune a vision transformer (ViT) model. In this case study, the trainer only trains the last head layer of a pretrained ViT model, so only the parameters of the last head layer should be exchanged between the server and client. Therefore, we need to create the following trainer which inherits the `VanillaTrainer` by overriding the `get_parameters` and `load_parameters` functions:
```python
from typing import Dict
from appfl.algorithm.trainer import VanillaTrainer

class ViTFineTuningTrainer(VanillaTrainer):
    def get_parameters(self) -> Dict:
        return {
            k: v.cpu() for k, v in self.model.heads.state_dict().items()
        }
        
    def load_parameters(self, params: Dict):
        self.model.heads.load_state_dict(params, strict=False)
```
There are two problems here:

(1) The current aggregator takes the `model` as the initialization parameter and assumes that all the model parameters will be aggregated during the aggregation process. However, ideally, the aggregator should aggregate whatever model parameters sent by the clients and it is not necessary that the aggregator to take the model architecture as the initialization parameters. - This PR fixes this issue to make the `model` as optional input parameter, and only aggregates the parameters sent by the clients instead of the whole set of model parameters.

(2) Currently, when users need to add a custom trainer/aggregator, they have to build `APPFL` from source and add the custom trainer/aggregator into the corresponding modules `appfl.algorithm.trainer/aggregator` - this is inconvenient for users who install `APPFL` directly via `pip install appfl.` Therefore, a new feature is added to allow user to load custom trainer/aggregator directly from its definition file by providing the file path as a configuration parameter `trainer_path/aggregator_path`.
## Release
This fix will be released as `appfl==1.0.1`