### PR TITLE
bugfix; removed duplicated ArgumentParser

### DIFF
--- a/examples/globus_compute/run.py
+++ b/examples/globus_compute/run.py
@@ -10,9 +10,6 @@ warnings.filterwarnings("ignore", category=DeprecationWarning)   # Ignore deprec
 argparser = argparse.ArgumentParser()
 argparser.add_argument('--server_config', type=str, default="./resources/config_gc/mnist/server_fedcompass.yaml")
 argparser.add_argument('--client_config', type=str, default="./resources/config_gc/mnist/clients.yaml")
-args = argparser.parse_args()
-
-argparser = argparse.ArgumentParser()
 argparser.add_argument("--compute_token", required=False)
 argparser.add_argument("--openid_token", required=False)
 args = argparser.parse_args()


### PR DESCRIPTION
The `ArgumentParser` was unintentionally created twice, causing the arguments assigned in the first instance to be overridden by the second. This issue has been resolved by ensuring only one `ArgumentParser` instance is used.