### PR TITLE
Fix dataset path and noniid typo

### DIFF
--- a/docs/tutorials/examples/dr_metric/appfl_dr_metric_grpc/client/resources/mnist_dataset.py
+++ b/docs/tutorials/examples/dr_metric/appfl_dr_metric_grpc/client/resources/mnist_dataset.py
@@ -46,7 +46,7 @@ def get_mnist(
         train_datasets = iid_partition(train_data_raw, num_clients)
     elif partition_strategy == "class_noniid":
         train_datasets = class_noniid_partition(train_data_raw, num_clients, **kwargs)
-    elif partition_strategy == "dirichlet_nomiid":
+    elif partition_strategy == "dirichlet_noniid":
         train_datasets = dirichlet_noniid_partition(
             train_data_raw, num_clients, **kwargs
         )

--- a/docs/tutorials/examples/dr_metric/appfl_dr_metric_mpi/resources/mnist_dataset.py
+++ b/docs/tutorials/examples/dr_metric/appfl_dr_metric_mpi/resources/mnist_dataset.py
@@ -46,7 +46,7 @@ def get_mnist(
         train_datasets = iid_partition(train_data_raw, num_clients)
     elif partition_strategy == "class_noniid":
         train_datasets = class_noniid_partition(train_data_raw, num_clients, **kwargs)
-    elif partition_strategy == "dirichlet_nomiid":
+    elif partition_strategy == "dirichlet_noniid":
         train_datasets = dirichlet_noniid_partition(
             train_data_raw, num_clients, **kwargs
         )

--- a/examples/resources/dataset/cifar10_dataset.py
+++ b/examples/resources/dataset/cifar10_dataset.py
@@ -46,7 +46,7 @@ def get_cifar10(
         train_datasets = iid_partition(train_data_raw, num_clients)
     elif partition_strategy == "class_noniid":
         train_datasets = class_noniid_partition(train_data_raw, num_clients, **kwargs)
-    elif partition_strategy == "dirichlet_nomiid":
+    elif partition_strategy == "dirichlet_noniid":
         train_datasets = dirichlet_noniid_partition(
             train_data_raw, num_clients, **kwargs
         )

--- a/examples/resources/dataset/mnist_dataset.py
+++ b/examples/resources/dataset/mnist_dataset.py
@@ -46,7 +46,7 @@ def get_mnist(
         train_datasets = iid_partition(train_data_raw, num_clients)
     elif partition_strategy == "class_noniid":
         train_datasets = class_noniid_partition(train_data_raw, num_clients, **kwargs)
-    elif partition_strategy == "dirichlet_nomiid":
+    elif partition_strategy == "dirichlet_noniid":
         train_datasets = dirichlet_noniid_partition(
             train_data_raw, num_clients, **kwargs
         )

--- a/examples/resources/dataset/mnist_dataset_dr.py
+++ b/examples/resources/dataset/mnist_dataset_dr.py
@@ -69,7 +69,7 @@ def get_mnist(
         train_datasets = class_noniid_partition_binary(
             train_data_raw, num_clients, **kwargs
         )
-    elif partition_strategy == "dirichlet_nomiid":
+    elif partition_strategy == "dirichlet_noniid":
         train_datasets = dirichlet_noniid_partition(
             train_data_raw, num_clients, **kwargs
         )

--- a/tests/resources/dataset/mnist_dataset.py
+++ b/tests/resources/dataset/mnist_dataset.py
@@ -19,7 +19,7 @@ def get_mnist(
     :param client_id: the client id
     """
     # Get the download directory for dataset
-    dir = os.getcwd() + "_data"
+    dir = os.path.join(os.getcwd(), "_data")
 
     # Root download the data if not already available.
     test_data_raw = torchvision.datasets.MNIST(
@@ -46,7 +46,7 @@ def get_mnist(
         train_datasets = iid_partition(train_data_raw, num_clients)
     elif partition_strategy == "class_noniid":
         train_datasets = class_noniid_partition(train_data_raw, num_clients, **kwargs)
-    elif partition_strategy == "dirichlet_nomiid":
+    elif partition_strategy == "dirichlet_noniid":
         train_datasets = dirichlet_noniid_partition(
             train_data_raw, num_clients, **kwargs
         )


### PR DESCRIPTION
## Summary
- fix dataset path for test MNIST dataset
- fix `dirichlet_noniid` typo across dataset helpers

## Testing
- `pytest -k serial tests/test_mnist.py -q` *(fails: ModuleNotFoundError: No module named 'torchvision')*

------
https://chatgpt.com/codex/tasks/task_e_686ef9cba57c832e8084a503b0c3ecf4