### PR TITLE
Fix typo in comment

### DIFF
--- a/src/appfl/run_serial.py
+++ b/src/appfl/run_serial.py
@@ -103,7 +103,7 @@ def run_serial(
             args=(
                 k,
                 weights[k],
-                # deepcopy the common model if there is no personalization, else use the the clients' own model
+                # deepcopy the common model if there is no personalization, else use the clients' own model
                 # the index is k+1, because the first model belongs to the server
                 copy.deepcopy(model) if not cfg.personalization else model[k + 1],
                 loss_fn,


### PR DESCRIPTION
## Summary
- fix typo in client algorithm initialization comment

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torchvision')*

------
https://chatgpt.com/codex/tasks/task_e_686f2a3c1cf4832e97a05982a06d58a6