### PR TITLE
Add virtual training time simulation

### DIFF
--- a/docs/users/scheduler.rst
+++ b/docs/users/scheduler.rst
@@ -7,6 +7,12 @@ APPFL scheduler is the interface between the communicator and the aggregator. Wh
 - :ref:`Vanilla Asynchronous Scheduler`
 - :ref:`Compass Asynchronous Scheduler`
 
+Clients may optionally provide ``train_time`` in their ``train_configs`` to
+simulate heterogeneous computing power. The trainer simply reports this
+configured duration to the scheduler without delaying execution so client
+arrival time is fully virtual. This works for both synchronous and
+asynchronous schedulers.
+
 All schedulers are inherited from the base class ``BaseScheduler``. If user wants to implement a new scheduler, the user needs to inherit the ``BaseScheduler`` and implement the ``schedule`` and ``get_num_global_epochs`` methods.
 
 .. note::

--- a/docs/users/server_agent.rst
+++ b/docs/users/server_agent.rst
@@ -123,6 +123,7 @@ For client configurations that are shared among all clients, it is composed of t
         - ``trainer``: The class name of the trainer you would like to use for client local training. The trainer name should be defined in ``src/appfl/trainer``. For example, ``VanillaTrainer`` simply updates the model for a certain number of epochs or batches.
         - ``mode``: For ``VanillaTrainer``, mode is a required configuration to with allowable values ``epoch`` or ``step`` to specify whether you want to train for a certain number of epochs or only a certain number of steps/batches.
         - ``num_local_steps`` / ``num_local_epochs``: Number of steps (if ``mode=step``) or epochs (if ``mode=epoch``) for an FL client in each local training round.
+        - ``train_time``: Target duration (in seconds) for local training. The trainer will report this duration to the server without waiting, enabling fully virtual timing.
         - ``optim``: Name of the optimizer to use from the ``torch.optim`` module.
         - ``optim_args``: Keyword arguments for the selected optimizer.
         - ``do_validation``: Whether to perform client-side validation in each training round.

--- a/examples/mpi/run_batched_mpi_async.py
+++ b/examples/mpi/run_batched_mpi_async.py
@@ -17,6 +17,12 @@ argparse.add_argument(
     "--client_config", type=str, default="./resources/configs/mnist/client_1.yaml"
 )
 argparse.add_argument("--num_clients", type=int, default=10)
+argparse.add_argument(
+    "--train_times",
+    type=str,
+    default=None,
+    help="Comma separated virtual training time per client",
+)
 args = argparse.parse_args()
 
 comm = MPI.COMM_WORLD
@@ -71,6 +77,10 @@ else:
     client_config = client_communicator.get_configuration()
     for client_agent in client_agents:
         client_agent.load_config(client_config)
+    if args.train_times is not None:
+        times = [float(t) for t in args.train_times.split(",")]
+        for idx, client_agent in enumerate(client_agents):
+            client_agent.trainer.train_configs.train_time = times[(client_batch[rank - 1][idx]) % len(times)]
     # Get and load the initial global model
     init_global_model = client_communicator.get_global_model(init_model=True)
     for client_agent in client_agents:

--- a/examples/mpi/run_mpi.py
+++ b/examples/mpi/run_mpi.py
@@ -14,6 +14,12 @@ argparse.add_argument(
 argparse.add_argument(
     "--client_config", type=str, default="./resources/configs/mnist/client_1.yaml"
 )
+argparse.add_argument(
+    "--train_times",
+    type=str,
+    default=None,
+    help="Comma separated virtual training time per client",
+)
 args = argparse.parse_args()
 
 comm = MPI.COMM_WORLD
@@ -49,6 +55,9 @@ else:
     # Load the configurations and initial global model
     client_config = client_communicator.get_configuration()
     client_agent.load_config(client_config)
+    if args.train_times is not None:
+        times = [float(t) for t in args.train_times.split(",")]
+        client_agent.trainer.train_configs.train_time = times[(rank - 1) % len(times)]
     init_global_model = client_communicator.get_global_model(init_model=True)
     client_agent.load_parameters(init_global_model)
     # Send the sample size to the server

--- a/examples/resources/configs/mnist/server_fedasync.yaml
+++ b/examples/resources/configs/mnist/server_fedasync.yaml
@@ -4,6 +4,8 @@ client_configs:
     trainer: "VanillaTrainer"
     mode: "step"
     num_local_steps: 100
+    # Optional virtual local training time in seconds
+    train_time: 0
     optim: "Adam"
     optim_args:
       lr: 0.001

--- a/examples/resources/configs/mnist/server_fedavg.yaml
+++ b/examples/resources/configs/mnist/server_fedavg.yaml
@@ -4,6 +4,8 @@ client_configs:
     trainer: "VanillaTrainer"
     mode: "step"
     num_local_steps: 100
+    # Optional virtual local training time in seconds
+    train_time: 0
     optim: "Adam"
     optim_args:
       lr: 0.001

--- a/examples/resources/configs/mnist/server_fedcompass.yaml
+++ b/examples/resources/configs/mnist/server_fedcompass.yaml
@@ -4,6 +4,8 @@ client_configs:
     trainer: "VanillaTrainer"
     mode: "step"
     num_local_steps: 100
+    # Optional virtual local training time in seconds
+    train_time: 0
     optim: "Adam"
     optim_args:
       lr: 0.001

--- a/examples/serial/run_serial.py
+++ b/examples/serial/run_serial.py
@@ -15,6 +15,12 @@ argparser.add_argument(
     "--client_config", type=str, default="./resources/configs/mnist/client_1.yaml"
 )
 argparser.add_argument("--num_clients", type=int, default=10)
+argparser.add_argument(
+    "--train_times",
+    type=str,
+    default=None,
+    help="Comma separated virtual training time per client",
+)
 args = argparser.parse_args()
 
 # Load server agent configurations and set the number of clients
@@ -54,6 +60,12 @@ client_agents = [
 client_config_from_server = server_agent.get_client_configs()
 for client_agent in client_agents:
     client_agent.load_config(client_config_from_server)
+
+# Set heterogeneous virtual training times if provided
+if args.train_times is not None:
+    times = [float(t) for t in args.train_times.split(",")]
+    for idx, client_agent in enumerate(client_agents):
+        client_agent.trainer.train_configs.train_time = times[idx % len(times)]
 
 # Load initial global model from the server
 init_global_model = server_agent.get_parameters(serial_run=True)

--- a/src/appfl/algorithm/scheduler/compass_scheduler.py
+++ b/src/appfl/algorithm/scheduler/compass_scheduler.py
@@ -33,7 +33,12 @@ class CompassScheduler(BaseScheduler):
         self._access_lock = threading.Lock()  # handle client requests as a queue
         self._timer_record = {}
         self.start_time = time.time()
+        self._virtual_time = 0.0
+        self._use_virtual_time = False
         super().__init__(scheduler_configs, aggregator, logger)
+
+    def _current_time(self) -> float:
+        return self._virtual_time if self._use_virtual_time else time.time() - self.start_time
 
     def get_parameters(
         self, **kwargs
@@ -53,6 +58,8 @@ class CompassScheduler(BaseScheduler):
                 )
                 if init_model_requests == 0:
                     self.start_time = time.time()
+                    if self._use_virtual_time:
+                        self._virtual_time = 0.0
             parameters = super().get_parameters(**kwargs)
             return parameters
 
@@ -73,7 +80,9 @@ class CompassScheduler(BaseScheduler):
             in next round or a `Future` object for the global model
         """
         with self._access_lock:
-            self._record_info(client_id)
+            if kwargs.get("train_time") is not None:
+                self._use_virtual_time = True
+            self._record_info(client_id, kwargs.get("train_time"))
             arrival_group_idx = (
                 self.client_info[client_id]["goa"]
                 if "goa" in self.client_info[client_id]
@@ -98,7 +107,7 @@ class CompassScheduler(BaseScheduler):
         for group_idx in self._timer_record:
             self._timer_record[group_idx].cancel()
 
-    def _record_info(self, client_id: Union[int, str]) -> None:
+    def _record_info(self, client_id: Union[int, str], train_time: float | None = None) -> None:
         """
         Record/update the client information for the coming client, including the client's
         - `timestamp`: the timestamp of the local model
@@ -106,13 +115,18 @@ class CompassScheduler(BaseScheduler):
         - `local_steps`: the number of local steps for the client in current round
         :param `client_id`: the id of the client
         """
-        curr_time = time.time() - self.start_time
+        curr_time = self._current_time()
         client_start_time = (
             self.client_info[client_id]["start_time"]
             if client_id in self.client_info
             else 0
         )
-        client_update_time = curr_time - client_start_time
+        if train_time is not None:
+            client_update_time = train_time
+            curr_time = max(curr_time, client_start_time + train_time)
+            self._virtual_time = curr_time
+        else:
+            client_update_time = curr_time - client_start_time
         client_steps = (
             self.client_info[client_id]["local_steps"]
             if client_id in self.client_info
@@ -189,7 +203,7 @@ class CompassScheduler(BaseScheduler):
         :return: `global_model`: current global model or a `Future` object for the global model
         :return: `local_steps`: the number of local steps for the client in next round
         """
-        curr_time = time.time() - self.start_time
+        curr_time = self._current_time()
         if curr_time > self.arrival_group[group_idx]["latest_arrival_time"]:
             self.arrival_group[group_idx]["clients"].remove(client_id)
             if len(self.arrival_group[group_idx]["clients"]) == 0:
@@ -285,7 +299,7 @@ class CompassScheduler(BaseScheduler):
         Assign the client to an arrival group based on the client estimated speed.
         :param `client_id`: the id of the client
         """
-        curr_time = time.time() - self.start_time
+        curr_time = self._current_time()
         if len(self.arrival_group) == 0:
             self.arrival_group[self.group_counter] = {
                 "clients": [client_id],
@@ -326,7 +340,7 @@ class CompassScheduler(BaseScheduler):
         Try to join the client to an existing arrival group.
         :return: whether the client can join an existing group or not
         """
-        curr_time = time.time() - self.start_time
+        curr_time = self._current_time()
         assigned_group = -1
         assigned_steps = -1
         for group in self.arrival_group:
@@ -359,7 +373,7 @@ class CompassScheduler(BaseScheduler):
         Create a new group for the client.
         :param `client_id`: the id of the client
         """
-        curr_time = time.time() - self.start_time
+        curr_time = self._current_time()
         assigned_steps = -1
         for group in self.arrival_group:
             if curr_time < self.arrival_group[group]["latest_arrival_time"]:
@@ -406,14 +420,15 @@ class CompassScheduler(BaseScheduler):
                 * self.scheduler_configs.latest_time_factor
             ),
         }
-        group_timer = threading.Timer(
-            self.arrival_group[self.group_counter]["latest_arrival_time"] - curr_time,
-            self._group_aggregation,
-            args=(self.group_counter,),
-            kwargs=kwargs,
-        )
-        group_timer.start()
-        self._timer_record[self.group_counter] = group_timer
+        if not self._use_virtual_time:
+            group_timer = threading.Timer(
+                self.arrival_group[self.group_counter]["latest_arrival_time"] - curr_time,
+                self._group_aggregation,
+                args=(self.group_counter,),
+                kwargs=kwargs,
+            )
+            group_timer.start()
+            self._timer_record[self.group_counter] = group_timer
         self.client_info[client_id]["goa"] = self.group_counter
         self.client_info[client_id]["local_steps"] = assigned_steps
         self.client_info[client_id]["start_time"] = curr_time

--- a/src/appfl/algorithm/trainer/vanilla_trainer.py
+++ b/src/appfl/algorithm/trainer/vanilla_trainer.py
@@ -82,6 +82,7 @@ class VanillaTrainer(BaseTrainer):
         if "round" in kwargs:
             self.round = kwargs["round"]
         self.val_results = {"round": self.round + 1}
+        round_start_time = time.time()
 
         # Store the previous model state for gradient computation
         send_gradient = self.train_configs.get("send_gradient", False)
@@ -278,6 +279,13 @@ class VanillaTrainer(BaseTrainer):
             self.model = self.model.module.to(self.device)
 
         self.round += 1
+
+        # Record training time and simulate heterogeneous speeds virtually
+        actual_time = time.time() - round_start_time
+        target_time = self.train_configs.get("train_time", None)
+        self.val_results["train_time"] = (
+            float(target_time) if target_time is not None else actual_time
+        )
 
         # Differential privacy
         if self.train_configs.get("use_dp", False):

--- a/tests/resources/configs/server_dr.yaml
+++ b/tests/resources/configs/server_dr.yaml
@@ -4,6 +4,8 @@ client_configs:
     trainer: "VanillaTrainer"
     mode: "step"
     num_local_steps: 100
+    # Simulated local training time in seconds
+    train_time: 0
     optim: "Adam"
     optim_args:
       lr: 0.001

--- a/tests/resources/configs/server_fedasync.yaml
+++ b/tests/resources/configs/server_fedasync.yaml
@@ -4,6 +4,8 @@ client_configs:
     trainer: "VanillaTrainer"
     mode: "step"
     num_local_steps: 2
+    # Simulated local training time in seconds
+    train_time: 0
     optim: "Adam"
     optim_args:
       lr: 0.001

--- a/tests/resources/configs/server_fedavg.yaml
+++ b/tests/resources/configs/server_fedavg.yaml
@@ -4,6 +4,8 @@ client_configs:
     trainer: "VanillaTrainer"
     mode: "step"
     num_local_steps: 2
+    # Simulated local training time in seconds
+    train_time: 0
     optim: "Adam"
     optim_args:
       lr: 0.001

--- a/tests/resources/configs/server_fedcompass.yaml
+++ b/tests/resources/configs/server_fedcompass.yaml
@@ -4,6 +4,8 @@ client_configs:
     trainer: "VanillaTrainer"
     mode: "step"
     num_local_steps: 2
+    # Simulated local training time in seconds
+    train_time: 0
     optim: "Adam"
     optim_args:
       lr: 0.001


### PR DESCRIPTION
## Summary
- document virtual `train_time` for schedulers and server agent
- report configured training time without delay in `VanillaTrainer`
- use virtual time inside `CompassScheduler` when `train_time` is provided
- add CLI arguments to examples for setting virtual train times

## Testing
- `pre-commit` *(fails: command not found)*
- `pytest -k ''` *(fails: ModuleNotFoundError: No module named 'torchvision')*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_686f2d79cefc832eab80737e5146f1bb