### PR TITLE
Disable pre-commit checks on draft PRs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,7 @@ on:
 
 jobs:
   build:
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
 
     runs-on: ubuntu-latest
     strategy:
@@ -47,6 +48,7 @@ jobs:
         mpirun -n 2 python3 -m pytest --with-mpi
 
   polaris:
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
     runs-on: ubuntu-22.04
     steps:
     - name: Trigger GitLab pipeline and monitor status

--- a/.pre-commit-ci.yaml
+++ b/.pre-commit-ci.yaml
@@ -1,0 +1,1 @@
+skip: [drafts]


### PR DESCRIPTION
## Summary
- disable pre-commit.ci runs for draft pull requests
- skip build and polaris jobs in GitHub Actions when the PR is a draft

## Testing
- `pre-commit run --files .pre-commit-ci.yaml .github/workflows/build.yml`
- `pytest -k '' -q --maxfail=1`

------
https://chatgpt.com/codex/tasks/task_e_68728e83fb58832e8fca160a545af495