### PR TITLE
Require explicit auth_token in NaiveAuthenticator

### DIFF
--- a/src/appfl/login_manager/ReadME.md
+++ b/src/appfl/login_manager/ReadME.md
@@ -24,21 +24,28 @@ Currently, we provide the two authenticators,
 - [`NaiveAuthenticator`](naive)
 - [`GlobusAuthenticator`](globus)
 
-`NaiveAuthenticator` simply uses hardcoded token for demonstration purposes.
+`NaiveAuthenticator` is a shared-secret scheme: the same `auth_token` must be configured on the server and on every client, and the server admits any peer that presents it. It is intended for demos and trusted-network testing only — production deployments should use `GlobusAuthenticator` (or another identity-bound mechanism).
+
+The token must be supplied explicitly (there is no default) and must be at least 16 characters. Mint one with:
+
+```bash
+python -c "import secrets; print(secrets.token_urlsafe(32))"
+```
+
+Then construct the authenticator with the same string on both sides:
 
 ```python
-class NaiveAuthenticator(BaseAuthenticator):
-    """
-    A naive authenticator that uses a hardcoded token for authentication.
-    It is only used for demonstration purposes.
-    """
-    def get_auth_token(self) -> Dict[str, str]:
-        return {
-            "auth_token": "appfl-naive-auth-token"
-        }
+from appfl.login_manager import NaiveAuthenticator
 
-    def validate_auth_token(self, token: dict) -> bool:
-        return token.get("auth_token") == "appfl-naive-auth-token"
+auth = NaiveAuthenticator(auth_token="<your-32-char-secret>")
+```
+
+When loaded from a config file, the equivalent shape is:
+
+```yaml
+authenticator: NaiveAuthenticator
+authenticator_args:
+  auth_token: "<your-32-char-secret>"
 ```
 
 ## Globus Authenticator

--- a/src/appfl/login_manager/naive/naive_authenticator.py
+++ b/src/appfl/login_manager/naive/naive_authenticator.py
@@ -28,7 +28,7 @@ class NaiveAuthenticator(BaseAuthenticator):
             raise ValueError(
                 f"auth_token must be a non-whitespace string of at least "
                 f"{self._MIN_TOKEN_LEN} characters. Generate one with "
-                f"`python -c \"import secrets; print(secrets.token_urlsafe(32))\"`."
+                f'`python -c "import secrets; print(secrets.token_urlsafe(32))"`.'
             )
         warnings.warn(
             "NaiveAuthenticator is a shared-secret scheme suitable only for "

--- a/src/appfl/login_manager/naive/naive_authenticator.py
+++ b/src/appfl/login_manager/naive/naive_authenticator.py
@@ -1,14 +1,41 @@
+import hmac
+import warnings
 from typing import Dict
 from appfl.login_manager import BaseAuthenticator
 
 
 class NaiveAuthenticator(BaseAuthenticator):
     """
-    A naive authenticator that uses a hardcoded token for authentication.
-    It is only used for demonstration purposes.
+    A naive shared-secret authenticator. The same `auth_token` string must
+    be configured on the server and on every client; the server admits any
+    peer that presents it.
+
+    This is intended for demos and trusted-network testing only. Production
+    deployments should use `GlobusAuthenticator` (or another identity-bound
+    mechanism). To mint a fresh token::
+
+        python -c "import secrets; print(secrets.token_urlsafe(32))"
     """
 
-    def __init__(self, *, auth_token: str = "appfl-naive-auth-token"):
+    _MIN_TOKEN_LEN = 16
+
+    def __init__(self, *, auth_token: str):
+        if not isinstance(auth_token, str):
+            raise TypeError(
+                f"auth_token must be a str, got {type(auth_token).__name__}"
+            )
+        if len(auth_token.strip()) < self._MIN_TOKEN_LEN:
+            raise ValueError(
+                f"auth_token must be a non-whitespace string of at least "
+                f"{self._MIN_TOKEN_LEN} characters. Generate one with "
+                f"`python -c \"import secrets; print(secrets.token_urlsafe(32))\"`."
+            )
+        warnings.warn(
+            "NaiveAuthenticator is a shared-secret scheme suitable only for "
+            "demos and trusted-network testing. Use GlobusAuthenticator (or "
+            "another identity-bound authenticator) in production.",
+            stacklevel=2,
+        )
         self.auth_token = auth_token
 
     def get_auth_token(self) -> Dict[str, str]:
@@ -17,4 +44,7 @@ class NaiveAuthenticator(BaseAuthenticator):
         }
 
     def validate_auth_token(self, token: dict) -> bool:
-        return token.get("auth_token") == self.auth_token
+        provided = token.get("auth_token")
+        if not isinstance(provided, str):
+            return False
+        return hmac.compare_digest(provided, self.auth_token)

--- a/tests/test_naive_authenticator.py
+++ b/tests/test_naive_authenticator.py
@@ -1,0 +1,112 @@
+"""Tests for appfl.login_manager.NaiveAuthenticator covering the contract
+that the authenticator (a) requires an explicit non-trivial auth_token,
+(b) emits a warning to discourage production use, and (c) compares tokens
+in constant time."""
+
+import warnings
+
+import pytest
+
+from appfl.login_manager import NaiveAuthenticator
+
+
+_GOOD_TOKEN = "x" * 32  # >= 16 chars
+
+
+def _make(token=_GOOD_TOKEN):
+    """Construct a NaiveAuthenticator while suppressing the demo warning."""
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        return NaiveAuthenticator(auth_token=token)
+
+
+def test_auth_token_is_required():
+    with pytest.raises(TypeError):
+        NaiveAuthenticator()  # type: ignore[call-arg]
+
+
+def test_legacy_default_token_is_rejected():
+    """The previously-hardcoded default must no longer be accepted as a
+    valid token (it's only 22 chars but more importantly it's public)."""
+    # The legacy default happened to be 22 chars, so length alone wouldn't
+    # reject it — we instead assert no caller can construct an authenticator
+    # without passing *some* token explicitly. That, plus the docs change
+    # removing the literal, is what closes the finding.
+    with pytest.raises(TypeError):
+        NaiveAuthenticator()  # type: ignore[call-arg]
+
+
+@pytest.mark.parametrize("bad", ["", "   ", "short", "a" * 15])
+def test_short_or_empty_tokens_are_rejected(bad):
+    with pytest.raises(ValueError):
+        NaiveAuthenticator(auth_token=bad)
+
+
+def test_non_string_token_is_rejected():
+    with pytest.raises(TypeError):
+        NaiveAuthenticator(auth_token=12345)  # type: ignore[arg-type]
+    with pytest.raises(TypeError):
+        NaiveAuthenticator(auth_token=None)  # type: ignore[arg-type]
+
+
+def test_construction_emits_warning():
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        NaiveAuthenticator(auth_token=_GOOD_TOKEN)
+    assert any("NaiveAuthenticator" in str(w.message) for w in caught), (
+        "Expected a warning mentioning NaiveAuthenticator on construction"
+    )
+
+
+def test_get_and_validate_round_trip():
+    auth = _make()
+    presented = auth.get_auth_token()
+    assert presented == {"auth_token": _GOOD_TOKEN}
+    assert auth.validate_auth_token(presented) is True
+
+
+def test_validate_rejects_wrong_token():
+    auth = _make()
+    assert auth.validate_auth_token({"auth_token": "y" * 32}) is False
+
+
+def test_validate_rejects_missing_field():
+    auth = _make()
+    assert auth.validate_auth_token({}) is False
+    assert auth.validate_auth_token({"other": _GOOD_TOKEN}) is False
+
+
+def test_validate_rejects_non_string_field():
+    auth = _make()
+    assert auth.validate_auth_token({"auth_token": None}) is False
+    assert auth.validate_auth_token({"auth_token": 12345}) is False
+
+
+def test_validate_uses_constant_time_compare(monkeypatch):
+    """The comparison should go through hmac.compare_digest, not `==`."""
+    import hmac
+
+    calls = []
+    real = hmac.compare_digest
+
+    def _spy(a, b):
+        calls.append((a, b))
+        return real(a, b)
+
+    monkeypatch.setattr(
+        "appfl.login_manager.naive.naive_authenticator.hmac.compare_digest", _spy
+    )
+    auth = _make()
+    auth.validate_auth_token({"auth_token": "y" * 32})
+    assert calls, "validate_auth_token did not route through hmac.compare_digest"
+
+
+def test_legacy_token_string_is_not_in_source():
+    """Defense in depth: ensure the previously-hardcoded literal is gone
+    from the implementation file."""
+    import inspect
+
+    from appfl.login_manager.naive import naive_authenticator
+
+    src = inspect.getsource(naive_authenticator)
+    assert "appfl-naive-auth-token" not in src


### PR DESCRIPTION
# Description

Fix a credential-disclosure vulnerability in
`appfl.login_manager.NaiveAuthenticator`.

Previously, the constructor signature was:

```python
def __init__(self, *, auth_token: str = "appfl-naive-auth-token"):
```

The default token `"appfl-naive-auth-token"` was a public string: it lived in
`src/appfl/login_manager/naive/naive_authenticator.py`, in the package
`ReadME.md`, and on PyPI. Any operator who enabled authentication without
explicitly overriding `auth_token` (e.g. by writing `NaiveAuthenticator()` or
configuring `authenticator: NaiveAuthenticator` with no `authenticator_args`)
ran a federation whose only "secret" was already known to anyone who had read
the source.

This token gates every authenticated RPC. Once a peer presents it, the server
admits them as a legitimate client — which means every other vulnerability
that requires "an authenticated peer" (model poisoning, identity spoofing,
the auth-gated unsafe-YAML branch, etc.) is reachable by anyone who can route
to the gRPC port.

## Changes

### `src/appfl/login_manager/naive/naive_authenticator.py`

1. **Removed the default `auth_token`.** The constructor now requires an
   explicit value; calling `NaiveAuthenticator()` raises `TypeError`. There
   is no in-source secret to leak.
2. **Added input validation.** The token must be a `str` of at least 16
   non-whitespace characters. The error message points at
   `secrets.token_urlsafe(32)` for minting one.
3. **Added a `warnings.warn`** on every construction making it clear that
   `NaiveAuthenticator` is for demos / trusted-network testing only and that
   `GlobusAuthenticator` (or another identity-bound mechanism) should be used
   in production. The warning fires once per construction, not once per
   request, so it stays out of the hot path.
4. **Switched comparison to `hmac.compare_digest`.** The original
   `==` comparison was timing-side-channel-leaky for an attacker who could
   issue many auth attempts. Constant-time compare also rejects non-`str`
   inputs explicitly, so a malformed `token` dict no longer raises.

### `src/appfl/login_manager/ReadME.md`

Replaced the demo block, which formerly inlined the literal
`"appfl-naive-auth-token"` in both `get_auth_token` and `validate_auth_token`,
with a short usage section that:

- Explains the shared-secret model and steers production users to
  `GlobusAuthenticator`.
- Shows how to mint a token with `python -c "import secrets;
  print(secrets.token_urlsafe(32))"`.
- Shows the equivalent YAML config under `authenticator_args`.

The updated docs no longer publish a working credential.

## Backwards compatibility

This is a **breaking change** for any caller that relied on the implicit
default. Concretely:

- `NaiveAuthenticator()` now raises `TypeError`. Callers must pass
  `auth_token=...` explicitly. The error message names the missing argument.
- `NaiveAuthenticator(auth_token="appfl-naive-auth-token")` still works
  syntactically (the validator accepts any 16+ char string), but anyone using
  that exact value gets exactly the same security posture they had before.
  The intent of the fix is that operators be forced to *think* about the
  token they configure; we deliberately do not blocklist the legacy literal,
  because doing so would create false confidence — `secrets.token_urlsafe`
  is the right answer.
- Tokens shorter than 16 characters now raise `ValueError`.
- Construction emits a `UserWarning`. Tests that construct
  `NaiveAuthenticator` should suppress it via
  `warnings.catch_warnings()` if they assert no warnings.

The notebooks under `docs/notebooks/launch_*_auth.ipynb` already use an
explicit token (`"A_SECRET_DEMO_TOKEN"`); they continue to work without
modification (though that string is itself short and only suitable for the
notebook demo). No example or test in the repo passes the literal
`"appfl-naive-auth-token"`, so nothing else needs to change.

### Fixes

No public GitHub issue is open for this finding.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (internal implementation changes)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update (no changes to the code)
- [ ] CI change (changes to CI workflows, packages, templates, etc.)
- [ ] Version changes (changes to the package or dependency versions)

## Testing

There were no tests covering `NaiveAuthenticator` before this PR. A new file
`tests/test_naive_authenticator.py` adds 14 tests (10 cases, one parametrized
4 ways).

Cases:

- `test_auth_token_is_required` — `NaiveAuthenticator()` raises `TypeError`.
- `test_legacy_default_token_is_rejected` — companion assertion that the
  no-argument construction is no longer possible.
- `test_short_or_empty_tokens_are_rejected` — parametrized across `""`,
  whitespace, `"short"`, and a 15-char string (just below the threshold).
- `test_non_string_token_is_rejected` — `int` and `None` raise `TypeError`.
- `test_construction_emits_warning` — the demo-only warning fires.
- `test_get_and_validate_round_trip` — happy path.
- `test_validate_rejects_wrong_token` — distinct same-length token returns
  `False`.
- `test_validate_rejects_missing_field` — missing or wrong dict key returns
  `False` instead of raising.
- `test_validate_rejects_non_string_field` — non-`str` values in the dict
  return `False` instead of raising.
- `test_validate_uses_constant_time_compare` — spies on
  `hmac.compare_digest` and asserts the validator routes through it.
- `test_legacy_token_string_is_not_in_source` — defense-in-depth grep
  asserting the literal `"appfl-naive-auth-token"` no longer appears in the
  implementation file.

## Other Pull Request Checklist

- [x] Code changes pass `pre-commit` (e.g., ruff, mypy, etc.) via `pre-commit run --all-files`.
- [x] Tests have been added to show the fix is effective or that the new feature works.
- [x] New and existing unit tests pass locally with the changes.
- [x] Docs have been updated and reviewed if relevant.