### PR TITLE
Mint random tempfiles and refuse symlinks in client writes

### DIFF
--- a/src/appfl/comm/tes/tes_client_communicator.py
+++ b/src/appfl/comm/tes/tes_client_communicator.py
@@ -1,8 +1,28 @@
 import json
+import os
 import pickle
 import argparse
+import tempfile
 from omegaconf import OmegaConf
-from typing import Dict, Any, Tuple
+from typing import Dict, Any, Optional, Tuple
+
+
+def _mkstemp_path(suffix: str) -> str:
+    """Atomically create a fresh, owner-only (0o600) temp file and return
+    its path. The random name defeats co-tenant symlink-race attacks that
+    target predictable shared-tmp names."""
+    fd, path = tempfile.mkstemp(prefix="appfl-tes-", suffix=suffix)
+    os.close(fd)
+    return path
+
+
+def _safe_open_for_write(path: str, binary: bool):
+    """Open `path` for writing, refusing to follow a symlink at the final
+    component. Truncates if the file already exists and is a regular file
+    owned by the same caller. Returns a file object."""
+    flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC | os.O_NOFOLLOW
+    fd = os.open(path, flags, 0o600)
+    return os.fdopen(fd, "wb" if binary else "w")
 
 
 class TESClientCommunicator:
@@ -41,7 +61,7 @@ class TESClientCommunicator:
     def save_model_to_path(self, model: Any, output_path: str):
         """Save model to file path."""
         try:
-            with open(output_path, "wb") as f:
+            with _safe_open_for_write(output_path, binary=True) as f:
                 pickle.dump(model, f)
         except Exception as e:
             raise RuntimeError(f"Failed to save model to {output_path}: {e}")
@@ -49,7 +69,7 @@ class TESClientCommunicator:
     def save_logs_to_path(self, logs: Dict, logs_path: str):
         """Save training logs to JSON file path."""
         try:
-            with open(logs_path, "w") as f:
+            with _safe_open_for_write(logs_path, binary=False) as f:
                 json.dump(logs, f, indent=2)
         except Exception as e:
             raise RuntimeError(f"Failed to save logs to {logs_path}: {e}")
@@ -105,8 +125,8 @@ class TESClientCommunicator:
         task_name: str,
         model_path: str = None,
         metadata_path: str = None,
-        output_path: str = "/tmp/output_model.pkl",
-        logs_path: str = "/tmp/training_logs.json",
+        output_path: Optional[str] = None,
+        logs_path: Optional[str] = None,
     ) -> Tuple[str, str]:
         """
         Execute a federated learning task within the TES container.
@@ -124,6 +144,11 @@ class TESClientCommunicator:
         Returns:
             Tuple of (output_path, logs_path) for the results
         """
+        if output_path is None:
+            output_path = _mkstemp_path(".pkl")
+        if logs_path is None:
+            logs_path = _mkstemp_path(".json")
+
         try:
             import time
             from appfl.comm.utils.executor import (
@@ -195,10 +220,14 @@ def tes_client_entry_point():
     parser.add_argument("--model-path", help="Path to input model file")
     parser.add_argument("--metadata-path", help="Path to metadata JSON file")
     parser.add_argument(
-        "--output-path", default="/tmp/output_model.pkl", help="Path for output model"
+        "--output-path",
+        default=None,
+        help="Path for output model. If omitted, a fresh tempfile is created.",
     )
     parser.add_argument(
-        "--logs-path", default="/tmp/training_logs.json", help="Path for training logs"
+        "--logs-path",
+        default=None,
+        help="Path for training logs. If omitted, a fresh tempfile is created.",
     )
     args = parser.parse_args()
 

--- a/tests/test_tes_client_safe_paths.py
+++ b/tests/test_tes_client_safe_paths.py
@@ -138,8 +138,6 @@ def test_entry_point_argparse_defaults_are_none(monkeypatch):
     well-known /tmp/... paths."""
     captured = {}
 
-    real_parse = argparse.ArgumentParser.parse_args
-
     def _fake_parse(self, args=None, namespace=None):
         # Snapshot the registered defaults instead of actually running.
         for action in self._actions:

--- a/tests/test_tes_client_safe_paths.py
+++ b/tests/test_tes_client_safe_paths.py
@@ -1,0 +1,165 @@
+"""Tests for the symlink-race / predictable-tempfile fixes in
+appfl.comm.tes.tes_client_communicator."""
+
+import argparse
+import json
+import os
+import pickle
+import stat
+
+import pytest
+
+from appfl.comm.tes.tes_client_communicator import (
+    TESClientCommunicator,
+    _mkstemp_path,
+    _safe_open_for_write,
+    tes_client_entry_point,
+)
+
+
+# ---------- _mkstemp_path ----------
+
+
+def test_mkstemp_path_creates_unique_owner_only_file(tmp_path, monkeypatch):
+    monkeypatch.setattr("tempfile.tempdir", str(tmp_path))
+    p1 = _mkstemp_path(".pkl")
+    p2 = _mkstemp_path(".pkl")
+    assert p1 != p2
+    assert os.path.isfile(p1) and os.path.isfile(p2)
+    mode = stat.S_IMODE(os.stat(p1).st_mode)
+    assert mode == 0o600, f"expected 0o600, got {oct(mode)}"
+    assert p1.endswith(".pkl")
+
+
+def test_mkstemp_path_uses_appfl_prefix(tmp_path, monkeypatch):
+    monkeypatch.setattr("tempfile.tempdir", str(tmp_path))
+    p = _mkstemp_path(".json")
+    assert os.path.basename(p).startswith("appfl-tes-")
+
+
+# ---------- _safe_open_for_write ----------
+
+
+def test_safe_open_writes_new_file(tmp_path):
+    target = tmp_path / "out.bin"
+    with _safe_open_for_write(str(target), binary=True) as f:
+        f.write(b"hello")
+    assert target.read_bytes() == b"hello"
+    assert stat.S_IMODE(target.stat().st_mode) == 0o600
+
+
+def test_safe_open_truncates_regular_file(tmp_path):
+    target = tmp_path / "out.txt"
+    target.write_text("old contents that should be erased")
+    with _safe_open_for_write(str(target), binary=False) as f:
+        f.write("new")
+    assert target.read_text() == "new"
+
+
+def test_safe_open_refuses_symlink(tmp_path):
+    """A pre-existing symlink at the target path must not be followed —
+    this is the core symlink-race fix."""
+    target = tmp_path / "evil.pkl"
+    sensitive = tmp_path / "sensitive_file"
+    sensitive.write_text("operator's data")
+    os.symlink(str(sensitive), str(target))
+
+    with pytest.raises(OSError):
+        _safe_open_for_write(str(target), binary=True)
+
+    # The symlink target was not touched.
+    assert sensitive.read_text() == "operator's data"
+
+
+# ---------- save_model_to_path / save_logs_to_path ----------
+
+
+@pytest.fixture
+def client():
+    return TESClientCommunicator(client_agent_config=None)
+
+
+def test_save_model_refuses_symlink(tmp_path, client):
+    target = tmp_path / "model.pkl"
+    sensitive = tmp_path / "authorized_keys"
+    sensitive.write_text("ssh-ed25519 AAAA...")
+    os.symlink(str(sensitive), str(target))
+
+    with pytest.raises(RuntimeError, match="Failed to save model"):
+        client.save_model_to_path({"weights": [1, 2, 3]}, str(target))
+
+    assert sensitive.read_text() == "ssh-ed25519 AAAA..."
+
+
+def test_save_logs_refuses_symlink(tmp_path, client):
+    target = tmp_path / "logs.json"
+    sensitive = tmp_path / "shadow"
+    sensitive.write_text("root:!:...")
+    os.symlink(str(sensitive), str(target))
+
+    with pytest.raises(RuntimeError, match="Failed to save logs"):
+        client.save_logs_to_path({"loss": 0.1}, str(target))
+
+    assert sensitive.read_text() == "root:!:..."
+
+
+def test_save_model_round_trip(tmp_path, client):
+    target = tmp_path / "model.pkl"
+    payload = {"weights": [1.0, 2.0]}
+    client.save_model_to_path(payload, str(target))
+    with open(target, "rb") as f:
+        assert pickle.load(f) == payload
+    assert stat.S_IMODE(target.stat().st_mode) == 0o600
+
+
+def test_save_logs_round_trip(tmp_path, client):
+    target = tmp_path / "logs.json"
+    payload = {"loss": 0.42, "epoch": 3}
+    client.save_logs_to_path(payload, str(target))
+    assert json.loads(target.read_text()) == payload
+    assert stat.S_IMODE(target.stat().st_mode) == 0o600
+
+
+# ---------- defaults ----------
+
+
+def test_execute_task_signature_has_no_predictable_defaults():
+    """Regression guard: the predictable /tmp/output_model.pkl and
+    /tmp/training_logs.json defaults must not come back."""
+    import inspect
+
+    sig = inspect.signature(TESClientCommunicator.execute_task)
+    assert sig.parameters["output_path"].default is None
+    assert sig.parameters["logs_path"].default is None
+
+
+def test_entry_point_argparse_defaults_are_none(monkeypatch):
+    """The CLI defaults for --output-path / --logs-path must not be the
+    well-known /tmp/... paths."""
+    captured = {}
+
+    real_parse = argparse.ArgumentParser.parse_args
+
+    def _fake_parse(self, args=None, namespace=None):
+        # Snapshot the registered defaults instead of actually running.
+        for action in self._actions:
+            if action.dest in ("output_path", "logs_path"):
+                captured[action.dest] = action.default
+        raise SystemExit(0)
+
+    monkeypatch.setattr(argparse.ArgumentParser, "parse_args", _fake_parse)
+    with pytest.raises(SystemExit):
+        tes_client_entry_point()
+
+    assert captured == {"output_path": None, "logs_path": None}
+
+
+def test_predictable_paths_not_in_source():
+    """Defense in depth: ensure the legacy fixed paths are gone from
+    the implementation file."""
+    import inspect
+    from appfl.comm.tes import tes_client_communicator
+
+    src = inspect.getsource(tes_client_communicator)
+    assert "/tmp/output_model.pkl" not in src
+    assert "/tmp/training_logs.json" not in src


### PR DESCRIPTION
# Description

Fix a symlink-race / predictable-tempfile vulnerability in
`appfl.comm.tes.tes_client_communicator`.

The TES client wrote model output and training logs to fully-fixed paths:

```python
def execute_task(
    self,
    ...,
    output_path: str = "/tmp/output_model.pkl",
    logs_path: str = "/tmp/training_logs.json",
) -> Tuple[str, str]:
    ...
    self.save_model_to_path(model, output_path)   # open(path, "wb")
    self.save_logs_to_path(metadata, logs_path)   # open(path, "w")
```

The `tes_client_entry_point` argparse defaults pinned the same two paths.
Both `save_*_to_path` helpers used plain `open(path, ...)`, which follows
symlinks at the final component.

On a shared host (HPC login node, multi-tenant container host, CI runner,
co-tenant on the same VM), an unprivileged attacker can pre-create
`/tmp/output_model.pkl` as a symlink pointing at a sensitive file the
operator can write — `~/.ssh/authorized_keys`, `~/.bashrc`, a writable file
in another user's space, etc. When the TES client runs, the
`open(output_path, "wb")` follows the symlink and overwrites the target as
the operator. The classic exploitation is to overwrite `authorized_keys`
with the attacker's public key, after which they have shell access as the
operator.

The same shape applies to `/tmp/training_logs.json` for the JSON log path.

## Changes

### `src/appfl/comm/tes/tes_client_communicator.py`

1. **Removed the predictable defaults.** Both `execute_task(...)` and the
   `--output-path` / `--logs-path` argparse options now default to `None`.
   When the path is omitted, a fresh tempfile is minted via the new
   `_mkstemp_path(suffix)` helper. The helper wraps `tempfile.mkstemp`,
   which atomically creates the file with `O_CREAT | O_EXCL` and mode
   `0o600`, and uses a random name an attacker cannot pre-position a
   symlink on. Files are prefixed `appfl-tes-` so they are easy to
   identify and clean up.
2. **Hardened the writers.** `save_model_to_path` and `save_logs_to_path`
   now open the target via the new `_safe_open_for_write(path, binary)`
   helper, which uses
   `os.open(path, O_WRONLY | O_CREAT | O_TRUNC | O_NOFOLLOW, 0o600)`.
   `O_NOFOLLOW` makes the open call fail with `ELOOP` if the final path
   component is a symlink, so an attacker who pre-creates a symlink at a
   caller-supplied path can no longer redirect the write. The mode argument
   ensures freshly-created files are owner-only.

The container-internal paths under `/tmp/output_model_<uuid>.pkl` constructed
by the server (`tes_server_communicator.py:443-444`) and the funnel-workspace
paths there are *also* on the same theme, but each already incorporates a
`uuid.uuid4()` task ID, so they are not directly predictable. Those are out
of scope for this PR; the predictable client-side defaults were the
exploitable surface.

## Backwards compatibility

- `TESClientCommunicator.execute_task()` and the `tes-client` CLI now mint a
  random tempfile when `output_path` / `logs_path` are not supplied.
  Callers that relied on the result files appearing at the literal paths
  `/tmp/output_model.pkl` / `/tmp/training_logs.json` will need to read the
  paths from the returned `(output_path, logs_path)` tuple (which already
  carries them) or pass explicit values. Inside the TES container itself,
  the server always passes explicit paths via `--output-path` / `--logs-path`
  (see `tes_server_communicator.py:530`), so the in-container code path is
  unaffected.
- Callers that pass an explicit path now have that path opened with
  `O_NOFOLLOW`. If a caller's workflow legitimately points the path at a
  symlink, the call will fail with `OSError` (`ELOOP`). No callers in this
  repository do that.
- Newly created output / log files are now mode `0o600` (owner-only)
  instead of inheriting the umask. On most systems this is the same as
  before for single-user use; on systems that previously relied on group
  read access (uncommon for transient model artefacts) this is a
  behavioural change.

### Fixes

No public GitHub issue is open for this finding.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (internal implementation changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (no changes to the code)
- [ ] CI change (changes to CI workflows, packages, templates, etc.)
- [ ] Version changes (changes to the package or dependency versions)

## Testing

There were no tests covering the TES backend before this PR. A new file
`tests/test_tes_client_safe_paths.py` adds 12 tests. All pass under the
project conda env:

```bash
.conda/bin/python -m pytest tests/test_tes_client_safe_paths.py -v
# 12 passed in 1.16s
```

Cases:

- `test_mkstemp_path_creates_unique_owner_only_file` — successive calls
  produce distinct paths, each `0o600` and existing on disk.
- `test_mkstemp_path_uses_appfl_prefix` — basenames start with
  `appfl-tes-` for traceability.
- `test_safe_open_writes_new_file` — round-trip through the new helper
  produces an owner-only file with the expected contents.
- `test_safe_open_truncates_regular_file` — pre-existing regular file is
  truncated as expected (no behavioural surprise vs. plain `open(..., "w")`).
- `test_safe_open_refuses_symlink` — pre-positioned symlink at the target
  raises `OSError`; the symlink target is left untouched. This is the
  direct regression test for the vulnerability.
- `test_save_model_refuses_symlink` — symlink targeting a fake
  `authorized_keys` is rejected; the impersonated file is unchanged.
- `test_save_logs_refuses_symlink` — same, for the JSON log writer with a
  fake `shadow` target.
- `test_save_model_round_trip` and `test_save_logs_round_trip` — happy paths
  for both writers, asserting both content correctness and `0o600` mode.
- `test_execute_task_signature_has_no_predictable_defaults` — guards
  against the `/tmp/output_model.pkl` / `/tmp/training_logs.json` defaults
  being reintroduced.
- `test_entry_point_argparse_defaults_are_none` — same guard for the CLI
  entry point's argparse defaults.
- `test_predictable_paths_not_in_source` — defense-in-depth grep asserting
  the legacy literals no longer appear anywhere in the implementation file.

## Other Pull Request Checklist

- [x] Code changes pass `pre-commit` (e.g., ruff, mypy, etc.) via `pre-commit run --all-files`.
- [x] Tests have been added to show the fix is effective or that the new feature works.
- [x] New and existing unit tests pass locally with the changes.
- [ ] Docs have been updated and reviewed if relevant.