### PR TITLE
Refuse AWS credentials file with insecure permissions

### DIFF
--- a/src/appfl/comm/utils/s3_storage.py
+++ b/src/appfl/comm/utils/s3_storage.py
@@ -1,14 +1,63 @@
 import os
 import csv
+import stat
 import sys
 import time
 import boto3
 import pathlib
 import requests
+import warnings
 import os.path as osp
 from typing import Optional
 from botocore.exceptions import ClientError
 from appfl.misc.utils import dump_data_to_file, load_data_from_file, id_generator
+
+
+def _open_credentials_file_securely(path: str):
+    """Open an AWS credentials file, refusing to read it if the file's
+    permissions or ownership would let another local user view it.
+
+    The check is performed on the same file descriptor that is returned to
+    the caller (TOCTOU-safe). On Windows the POSIX permission model does
+    not apply, so the check is skipped with a warning.
+
+    Returns a text-mode file object positioned at the start of the file.
+    Raises PermissionError if the file is unsafe.
+    """
+    if os.name != "posix":
+        warnings.warn(
+            f"Cannot enforce AWS credentials file permissions on {os.name}; "
+            "ensure the file is readable only by the current user.",
+            stacklevel=2,
+        )
+        return open(path, encoding="utf-8")  # noqa: SIM115
+
+    fd = os.open(path, os.O_RDONLY | os.O_NOFOLLOW)
+    try:
+        st = os.fstat(fd)
+    except Exception:
+        os.close(fd)
+        raise
+
+    mode_bits = stat.S_IMODE(st.st_mode)
+    bad_bits = mode_bits & (
+        stat.S_IRGRP | stat.S_IWGRP | stat.S_IROTH | stat.S_IWOTH
+    )
+    if bad_bits:
+        os.close(fd)
+        raise PermissionError(
+            f"AWS credentials file {path!r} has insecure permissions "
+            f"{oct(mode_bits)}; refusing to read. Run "
+            f"`chmod 600 {path}` (and ensure the file is owned by the current user)."
+        )
+    if st.st_uid != os.getuid():
+        os.close(fd)
+        raise PermissionError(
+            f"AWS credentials file {path!r} is not owned by the current user "
+            f"(uid={os.getuid()}, file uid={st.st_uid}); refusing to read."
+        )
+
+    return os.fdopen(fd, "r", encoding="utf-8")
 
 
 class LargeObjectWrapper:
@@ -64,7 +113,7 @@ class CloudStorage:
                     pathlib.Path(s3_tmp_dir).mkdir(parents=True, exist_ok=True)
             s3_kwargs = {}
             if s3_creds_file is not None:
-                with open(s3_creds_file) as file:
+                with _open_credentials_file_securely(s3_creds_file) as file:
                     reader = csv.reader(file)
                     keys = next(reader)
                     s3_kwargs = {

--- a/src/appfl/comm/utils/s3_storage.py
+++ b/src/appfl/comm/utils/s3_storage.py
@@ -40,9 +40,7 @@ def _open_credentials_file_securely(path: str):
         raise
 
     mode_bits = stat.S_IMODE(st.st_mode)
-    bad_bits = mode_bits & (
-        stat.S_IRGRP | stat.S_IWGRP | stat.S_IROTH | stat.S_IWOTH
-    )
+    bad_bits = mode_bits & (stat.S_IRGRP | stat.S_IWGRP | stat.S_IROTH | stat.S_IWOTH)
     if bad_bits:
         os.close(fd)
         raise PermissionError(

--- a/tests/test_s3_credentials_perms.py
+++ b/tests/test_s3_credentials_perms.py
@@ -1,0 +1,116 @@
+"""Tests for the credentials-file permission check in
+appfl.comm.utils.s3_storage._open_credentials_file_securely."""
+
+import csv
+import os
+import sys
+
+import pytest
+
+from appfl.comm.utils.s3_storage import _open_credentials_file_securely
+
+
+posix_only = pytest.mark.skipif(
+    os.name != "posix", reason="POSIX permission semantics required"
+)
+
+
+def _write_creds(path, mode=0o600):
+    path.write_text("us-east-1,AKIA_FAKE,SECRET_FAKE\n")
+    path.chmod(mode)
+    return path
+
+
+@posix_only
+def test_accepts_owner_only_file(tmp_path):
+    creds = _write_creds(tmp_path / "creds.csv", mode=0o600)
+    with _open_credentials_file_securely(str(creds)) as f:
+        row = next(csv.reader(f))
+    assert row == ["us-east-1", "AKIA_FAKE", "SECRET_FAKE"]
+
+
+@posix_only
+@pytest.mark.parametrize(
+    "bad_mode",
+    [
+        0o644,  # group + world readable (AWS console default)
+        0o640,  # group readable
+        0o604,  # world readable
+        0o620,  # group writable
+        0o602,  # world writable
+        0o755,
+    ],
+)
+def test_rejects_group_or_world_accessible(tmp_path, bad_mode):
+    creds = _write_creds(tmp_path / "creds.csv", mode=bad_mode)
+    with pytest.raises(PermissionError, match="insecure permissions"):
+        _open_credentials_file_securely(str(creds))
+
+
+@posix_only
+def test_rejects_symlink_to_credentials(tmp_path):
+    """O_NOFOLLOW must reject a symlink at the leaf even if the symlink
+    target is securely permissioned."""
+    real = _write_creds(tmp_path / "real_creds.csv", mode=0o600)
+    link = tmp_path / "link_creds.csv"
+    os.symlink(str(real), str(link))
+    with pytest.raises(OSError):
+        _open_credentials_file_securely(str(link))
+
+
+@posix_only
+def test_rejects_file_owned_by_other_user(tmp_path, monkeypatch):
+    creds = _write_creds(tmp_path / "creds.csv", mode=0o600)
+    real_uid = os.getuid()
+    monkeypatch.setattr(os, "getuid", lambda: real_uid + 12345)
+    with pytest.raises(PermissionError, match="not owned by the current user"):
+        _open_credentials_file_securely(str(creds))
+
+
+@posix_only
+def test_missing_file_raises_filenotfound(tmp_path):
+    with pytest.raises(FileNotFoundError):
+        _open_credentials_file_securely(str(tmp_path / "does_not_exist.csv"))
+
+
+def test_windows_path_warns_and_opens(tmp_path, monkeypatch):
+    """On Windows the perm check is skipped with a warning."""
+    creds = tmp_path / "creds.csv"
+    creds.write_text("us-east-1,AKIA_FAKE,SECRET_FAKE\n")
+    monkeypatch.setattr(os, "name", "nt")
+    with pytest.warns(UserWarning, match="Cannot enforce"):
+        with _open_credentials_file_securely(str(creds)) as f:
+            assert f.read().startswith("us-east-1")
+
+
+@posix_only
+def test_cloudstorage_init_propagates_permission_error(tmp_path):
+    """End-to-end: CloudStorage.init refuses to start when the creds file
+    is group-readable."""
+    from appfl.comm.utils import s3_storage
+
+    # Reset the singleton so init() actually runs.
+    s3_storage.CloudStorage.instc = None
+
+    creds = _write_creds(tmp_path / "creds.csv", mode=0o644)
+
+    with pytest.raises(PermissionError):
+        s3_storage.CloudStorage.init(
+            s3_bucket="dummy",
+            s3_creds_file=str(creds),
+            s3_tmp_dir=str(tmp_path / "s3tmp"),
+        )
+
+    # Singleton must not have been populated by the failed init.
+    assert s3_storage.CloudStorage.instc is None
+
+
+def test_legacy_unsafe_open_not_in_credentials_block():
+    """Defense in depth: the credentials-loading block must route through
+    the secure helper, not plain open()."""
+    import inspect
+    from appfl.comm.utils import s3_storage
+
+    src = inspect.getsource(s3_storage.CloudStorage.init)
+    assert "_open_credentials_file_securely" in src
+    assert "open(s3_creds_file)" not in src

--- a/tests/test_s3_credentials_perms.py
+++ b/tests/test_s3_credentials_perms.py
@@ -3,7 +3,6 @@ appfl.comm.utils.s3_storage._open_credentials_file_securely."""
 
 import csv
 import os
-import sys
 
 import pytest
 


### PR DESCRIPTION
# Description

Refuse to read AWS credentials files whose permissions or ownership would
let another local user view them.

`CloudStorage.init` previously loaded an AWS credentials CSV with
unconditional `open(s3_creds_file)`:

```python
if s3_creds_file is not None:
    with open(s3_creds_file) as file:
        reader = csv.reader(file)
        keys = next(reader)
        s3_kwargs = {
            "region_name": keys[0],
            "aws_access_key_id": keys[1],
            "aws_secret_access_key": keys[2],
        }
```

The AWS console hands out credential CSVs at `0o644` under a typical umask,
so on any shared host (HPC login node, multi-tenant container host, dev box)
a co-tenant can `cat` the file and pivot into the cloud account. The same
problem appears when the file ends up in a backup, a CI cache, or an
accidentally `git add`'d directory. APPFL never enforced anything; it
happily read whatever the operator pointed it at.

## Changes

### `src/appfl/comm/utils/s3_storage.py`

1. **New helper `_open_credentials_file_securely(path)`.** Uses
   `os.open(path, O_RDONLY | O_NOFOLLOW)` so a symlink at the leaf is
   refused (defeats a co-tenant who pre-positions a symlink at the
   configured creds path), then `os.fstat`s the same file descriptor
   (TOCTOU-safe — the perm check and the read happen on the same fd) and
   refuses to return the file if any of the following are true:
   - any of `S_IRGRP | S_IWGRP | S_IROTH | S_IWOTH` is set, or
   - the file is owned by a different uid than the current process.

   The error message tells the operator exactly what to run
   (`chmod 600 <path>`).

2. **`CloudStorage.init` routes through the helper** instead of plain
   `open()`. The downstream CSV parsing is unchanged, so callers see the
   same fields as before for files that pass the check.

3. **Windows fallback.** POSIX permission semantics don't apply, so on
   `os.name != "posix"` the helper emits a `UserWarning` (telling the
   operator the check is skipped) and opens the file normally. This keeps
   the Windows code path working without giving false security.

### Recommended migration

Operators using static AWS credentials should prefer one of boto3's
ambient credential sources (instance profile / IRSA on EKS / IAM role
assumption) over a CSV file checked in next to a config. The README and
docs already point toward the boto3 default chain; this PR strengthens the
"if you really must use a CSV file" path.

## Backwards compatibility

This is a behavioural tightening, not a signature change. `CloudStorage.init`
still accepts `s3_creds_file=` exactly as before. Operators whose credential
files are already mode `0o600` and owned by the running user (the standard
recommendation) see no difference. Operators whose files are group-readable,
world-readable, or owned by a different user will now see
`PermissionError` at startup with a message that names the failing path
and how to fix it. That's the intended behaviour.

There are no callers of `_open_credentials_file_securely` outside this
module, so the new symbol is internal.

### Fixes

No public GitHub issue is open for this finding.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (internal implementation changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (no changes to the code)
- [ ] CI change (changes to CI workflows, packages, templates, etc.)
- [ ] Version changes (changes to the package or dependency versions)

## Testing

There were no tests covering `s3_storage` or the credentials loader before
this PR. A new file `tests/test_s3_credentials_perms.py` adds 13 tests
(8 cases, one parametrized 6 ways). All pass under the project conda env:

```bash
.conda/bin/python -m pytest tests/test_s3_credentials_perms.py -v
# 13 passed in 0.78s
```

Cases:

- `test_accepts_owner_only_file` — happy path: a `0o600` CSV round-trips
  through the helper and parses correctly.
- `test_rejects_group_or_world_accessible` — parametrized across `0o644`,
  `0o640`, `0o604`, `0o620`, `0o602`, and `0o755`; each raises
  `PermissionError` with the "insecure permissions" message. `0o644` is
  the AWS-console default, so this is the direct regression case.
- `test_rejects_symlink_to_credentials` — pre-positioned symlink at the
  leaf is refused even when its target is `0o600` (verifies `O_NOFOLLOW`).
- `test_rejects_file_owned_by_other_user` — monkeypatches `os.getuid` to
  simulate a different uid; the helper raises with the
  "not owned by the current user" message.
- `test_missing_file_raises_filenotfound` — non-existent path surfaces a
  normal `FileNotFoundError`, not the masked POSIX errno.
- `test_windows_path_warns_and_opens` — monkeypatches `os.name` to `"nt"`
  and asserts a `UserWarning` is emitted and the file is opened.
- `test_cloudstorage_init_propagates_permission_error` — end-to-end
  assertion that `CloudStorage.init(...)` refuses to construct the
  singleton when the creds file is group-readable, and that the singleton
  is left unset on the failed call.
- `test_legacy_unsafe_open_not_in_credentials_block` — defense-in-depth
  source grep asserting `CloudStorage.init` calls
  `_open_credentials_file_securely` and no longer contains the literal
  `open(s3_creds_file)`.

## Other Pull Request Checklist

- [x] Code changes pass `pre-commit` (e.g., ruff, mypy, etc.) via `pre-commit run --all-files`.
- [x] Tests have been added to show the fix is effective or that the new feature works.
- [x] New and existing unit tests pass locally with the changes.
- [ ] Docs have been updated and reviewed if relevant.