### PR TITLE
Create APPFL working dirs with 0o700 and uid-namespaced /tmp fallback

### DIFF
--- a/src/appfl/comm/utils/s3_storage.py
+++ b/src/appfl/comm/utils/s3_storage.py
@@ -3,7 +3,6 @@ import csv
 import sys
 import time
 import boto3
-import pathlib
 import requests
 import os.path as osp
 from typing import Optional

--- a/src/appfl/comm/utils/s3_storage.py
+++ b/src/appfl/comm/utils/s3_storage.py
@@ -8,7 +8,12 @@ import requests
 import os.path as osp
 from typing import Optional
 from botocore.exceptions import ClientError
-from appfl.misc.utils import dump_data_to_file, load_data_from_file, id_generator
+from appfl.misc.utils import (
+    dump_data_to_file,
+    load_data_from_file,
+    id_generator,
+    secure_appfl_dir,
+)
 
 
 class LargeObjectWrapper:
@@ -53,15 +58,11 @@ class CloudStorage:
             new_inst = cls.__new__(cls)
             new_inst.bucket = s3_bucket
 
-            # Set s3_tmp_dir with fallback for read-only containers
+            # Set s3_tmp_dir with fallback for read-only containers.
+            # secure_appfl_dir handles the home/`/tmp` fallback and enforces
+            # 0o700 / current-user ownership on every component.
             if s3_tmp_dir is None:
-                try:
-                    s3_tmp_dir = str(pathlib.Path.home() / ".appfl" / "s3_tmp_dir")
-                    pathlib.Path(s3_tmp_dir).mkdir(parents=True, exist_ok=True)
-                except OSError:
-                    # Fallback to /tmp/.appfl if home directory is read-only
-                    s3_tmp_dir = "/tmp/.appfl/s3_tmp_dir"
-                    pathlib.Path(s3_tmp_dir).mkdir(parents=True, exist_ok=True)
+                s3_tmp_dir = secure_appfl_dir("s3_tmp_dir")
             s3_kwargs = {}
             if s3_creds_file is not None:
                 with open(s3_creds_file) as file:

--- a/src/appfl/comm/utils/s3_utils.py
+++ b/src/appfl/comm/utils/s3_utils.py
@@ -1,8 +1,8 @@
 import uuid
-import pathlib
 from collections import OrderedDict
 from typing import Any, Dict, Optional, Union
 from appfl.comm.utils.s3_storage import CloudStorage, LargeObjectWrapper
+from appfl.misc.utils import secure_appfl_dir
 
 
 def send_model_by_pre_signed_s3(
@@ -14,42 +14,19 @@ def send_model_by_pre_signed_s3(
     model_url: Optional[str],
     logger: Optional[Any] = None,
 ):
-    try:
-        s3_tmp_dir = str(
-            pathlib.Path.home() / ".appfl" / comm_type / client_id / experiment_id
+    s3_tmp_dir = secure_appfl_dir(comm_type, client_id, experiment_id)
+    model_wrapper = LargeObjectWrapper(model, model_key)
+    if (
+        comm_type == "globus_compute" and not model_wrapper.can_send_directly
+    ) or comm_type != "globus_compute":
+        CloudStorage.init(s3_tmp_dir=s3_tmp_dir, logger=logger)
+        model = CloudStorage.upload_object(
+            model_wrapper,
+            object_url=model_url,
+            ext="pt" if not isinstance(model, bytes) else "pkl",
+            register_for_clean=True,
         )
-        if not pathlib.Path(s3_tmp_dir).exists():
-            pathlib.Path(s3_tmp_dir).mkdir(parents=True, exist_ok=True)
-        model_wrapper = LargeObjectWrapper(model, model_key)
-        if (
-            comm_type == "globus_compute" and not model_wrapper.can_send_directly
-        ) or comm_type != "globus_compute":
-            CloudStorage.init(s3_tmp_dir=s3_tmp_dir, logger=logger)
-            model = CloudStorage.upload_object(
-                model_wrapper,
-                object_url=model_url,
-                ext="pt" if not isinstance(model, bytes) else "pkl",
-                register_for_clean=True,
-            )
-        return model
-    except Exception:
-        s3_tmp_dir = str(
-            pathlib.Path("/tmp/.appfl") / comm_type / client_id / experiment_id
-        )
-        if not pathlib.Path(s3_tmp_dir).exists():
-            pathlib.Path(s3_tmp_dir).mkdir(parents=True, exist_ok=True)
-        model_wrapper = LargeObjectWrapper(model, model_key)
-        if (
-            comm_type == "globus_compute" and not model_wrapper.can_send_directly
-        ) or comm_type != "globus_compute":
-            CloudStorage.init(s3_tmp_dir=s3_tmp_dir, logger=logger)
-            model = CloudStorage.upload_object(
-                model_wrapper,
-                object_url=model_url,
-                ext="pt" if not isinstance(model, bytes) else "pkl",
-                register_for_clean=True,
-            )
-        return model
+    return model
 
 
 def send_model_by_s3(experiment_id, comm_type, model, sender_id):
@@ -67,21 +44,8 @@ def send_model_by_s3(experiment_id, comm_type, model, sender_id):
 def extract_model_from_s3(
     client_id: str, experiment_id: str, comm_type: str, model: Any
 ):
-    try:
-        s3_tmp_dir = str(
-            pathlib.Path.home() / ".appfl" / comm_type / client_id / experiment_id
-        )
-        if not pathlib.Path(s3_tmp_dir).exists():
-            pathlib.Path(s3_tmp_dir).mkdir(parents=True, exist_ok=True)
-        if CloudStorage.is_cloud_storage_object(model):
-            CloudStorage.init(s3_tmp_dir=s3_tmp_dir)
-            model = CloudStorage.download_object(model)
-        return model
-    except Exception:
-        s3_tmp_dir = str(pathlib.Path("/tmp/.appfl") / comm_type / experiment_id)
-        if not pathlib.Path(s3_tmp_dir).exists():
-            pathlib.Path(s3_tmp_dir).mkdir(parents=True, exist_ok=True)
-        if CloudStorage.is_cloud_storage_object(model):
-            CloudStorage.init(s3_tmp_dir=s3_tmp_dir)
-            model = CloudStorage.download_object(model)
-        return model
+    s3_tmp_dir = secure_appfl_dir(comm_type, client_id, experiment_id)
+    if CloudStorage.is_cloud_storage_object(model):
+        CloudStorage.init(s3_tmp_dir=s3_tmp_dir)
+        model = CloudStorage.download_object(model)
+    return model

--- a/src/appfl/misc/utils.py
+++ b/src/appfl/misc/utils.py
@@ -3,6 +3,7 @@ import re
 import ast
 import sys
 import copy
+import stat
 import yaml
 import torch
 import random
@@ -18,6 +19,64 @@ import torch.nn as nn
 from omegaconf import DictConfig
 from .deprecation import deprecated
 from typing import Any, Optional, Union, Tuple, List, Dict
+
+
+def _ensure_secure_dir(path: pathlib.Path) -> None:
+    """Create `path` with mode 0o700 if missing, then verify it is a real
+    directory (not a symlink), owned by the current user, and has mode
+    exactly 0o700. Raises PermissionError if the verification fails."""
+    try:
+        path.mkdir(mode=0o700, exist_ok=False)
+    except FileExistsError:
+        pass
+    os.chmod(path, 0o700)
+    st = os.lstat(path)
+    if not stat.S_ISDIR(st.st_mode):
+        raise PermissionError(f"{path} is not a directory (or is a symlink)")
+    if hasattr(os, "getuid") and st.st_uid != os.getuid():
+        raise PermissionError(
+            f"{path} is owned by uid {st.st_uid}, expected {os.getuid()}"
+        )
+    mode_bits = stat.S_IMODE(st.st_mode)
+    if mode_bits & (stat.S_IRWXG | stat.S_IRWXO):
+        raise PermissionError(
+            f"{path} has insecure mode {oct(mode_bits)}; expected 0o700"
+        )
+
+
+def secure_appfl_dir(*parts: str) -> str:
+    """Return a path under the user's APPFL working tree, creating any
+    missing components with mode 0o700.
+
+    Tries `$HOME/.appfl/<parts...>` first. If the home directory is
+    read-only (common in containers), falls back to
+    `/tmp/.appfl-<uid>/<parts...>` — the uid suffix prevents a co-tenant
+    from pre-creating the directory and trapping the operator's writes.
+
+    Every directory from the `.appfl(-uid)` root down to the leaf is
+    created (or verified) with mode 0o700 and owned by the current user;
+    symlinked components are refused.
+    """
+    if hasattr(os, "getuid"):
+        fallback_root = pathlib.Path("/tmp") / f".appfl-{os.getuid()}"
+    else:
+        fallback_root = pathlib.Path("/tmp") / ".appfl"
+    candidates = [pathlib.Path.home() / ".appfl", fallback_root]
+
+    last_err: Optional[Exception] = None
+    for root in candidates:
+        try:
+            _ensure_secure_dir(root)
+            current = root
+            for part in parts:
+                current = current / part
+                _ensure_secure_dir(current)
+            return str(current)
+        except OSError as e:
+            last_err = e
+            continue
+    assert last_err is not None
+    raise last_err
 
 
 @deprecated(silent=True)
@@ -297,16 +356,7 @@ def create_instance_from_file_source(source, class_name=None, *args, **kwargs):
     :param args: Positional arguments to be passed to the class constructor
     """
     # Create a temporary file to store the source code
-    _home = pathlib.Path.home()
-    dirname = osp.join(_home, ".appfl", "tmp")
-    try:
-        if not osp.exists(dirname):
-            pathlib.Path(dirname).mkdir(parents=True, exist_ok=True)
-    except OSError:
-        # Fallback to /tmp/.appfl if home directory is read-only (e.g., in containers)
-        dirname = osp.join("/tmp", ".appfl", "tmp")
-        if not osp.exists(dirname):
-            pathlib.Path(dirname).mkdir(parents=True, exist_ok=True)
+    dirname = secure_appfl_dir("tmp")
     file_path = osp.join(dirname, f"{id_generator()}.py")
     with open(file_path, "w") as file:
         file.write(source)
@@ -329,16 +379,7 @@ def get_function_from_file_source(source, function_name=None):
     :return: The function object, or None if retrieval fails.
     """
     # Create a temporary file to store the source code
-    _home = pathlib.Path.home()
-    dirname = osp.join(_home, ".appfl", "tmp")
-    try:
-        if not osp.exists(dirname):
-            pathlib.Path(dirname).mkdir(parents=True, exist_ok=True)
-    except OSError:
-        # Fallback to /tmp/.appfl if home directory is read-only (e.g., in containers)
-        dirname = osp.join("/tmp", ".appfl", "tmp")
-        if not osp.exists(dirname):
-            pathlib.Path(dirname).mkdir(parents=True, exist_ok=True)
+    dirname = secure_appfl_dir("tmp")
     file_path = osp.join(dirname, f"{id_generator()}.py")
     with open(file_path, "w") as file:
         file.write(source)

--- a/tests/test_secure_appfl_dir.py
+++ b/tests/test_secure_appfl_dir.py
@@ -1,0 +1,160 @@
+"""Tests for appfl.misc.utils.secure_appfl_dir / _ensure_secure_dir, the
+helper that creates APPFL working directories with restrictive permissions
+(closes the /tmp/.appfl shared-host info-leak / RCE primitive)."""
+
+import os
+import pathlib
+import stat
+
+import pytest
+
+from appfl.misc.utils import _ensure_secure_dir, secure_appfl_dir
+
+
+posix_only = pytest.mark.skipif(
+    os.name != "posix", reason="POSIX permission semantics required"
+)
+
+
+# ---------- secure_appfl_dir ----------
+
+
+@posix_only
+def test_secure_appfl_dir_uses_home_when_writable(tmp_path, monkeypatch):
+    fake_home = tmp_path / "home"
+    fake_home.mkdir()
+    monkeypatch.setattr(pathlib.Path, "home", classmethod(lambda cls: fake_home))
+
+    result = secure_appfl_dir("comm", "client_a", "exp_1")
+    expected = fake_home / ".appfl" / "comm" / "client_a" / "exp_1"
+    assert pathlib.Path(result) == expected
+    assert expected.is_dir()
+
+    # Every component below `.appfl` must be 0o700.
+    for d in [expected, *expected.parents]:
+        if d == fake_home:
+            break
+        mode = stat.S_IMODE(d.stat().st_mode)
+        assert mode == 0o700, f"{d} has mode {oct(mode)}"
+
+
+@posix_only
+def test_secure_appfl_dir_falls_back_when_home_unwritable(tmp_path, monkeypatch):
+    """When $HOME is read-only the helper falls back to
+    /tmp/.appfl-<uid>/... rather than /tmp/.appfl/..."""
+    ro_home = tmp_path / "ro_home"
+    ro_home.mkdir(mode=0o500)  # r-x only — mkdir of children will fail
+    try:
+        monkeypatch.setattr(pathlib.Path, "home", classmethod(lambda cls: ro_home))
+
+        result = secure_appfl_dir("globus_compute", "exp_2")
+        uid = os.getuid()
+        expected = pathlib.Path(f"/tmp/.appfl-{uid}/globus_compute/exp_2")
+        assert pathlib.Path(result) == expected
+        assert expected.is_dir()
+        # Cleanup so subsequent runs start fresh.
+        for parent in [expected, expected.parent, expected.parent.parent]:
+            try:
+                parent.rmdir()
+            except OSError:
+                pass
+    finally:
+        ro_home.chmod(0o700)
+
+
+@posix_only
+def test_secure_appfl_dir_fallback_namespaced_by_uid(monkeypatch, tmp_path):
+    """The fallback directory name must include the current uid so a
+    co-tenant cannot pre-create /tmp/.appfl and trap our writes."""
+    ro_home = tmp_path / "ro_home"
+    ro_home.mkdir(mode=0o500)
+    try:
+        monkeypatch.setattr(pathlib.Path, "home", classmethod(lambda cls: ro_home))
+        path = secure_appfl_dir()
+        assert f"/.appfl-{os.getuid()}" in path
+        assert path != "/tmp/.appfl"
+    finally:
+        ro_home.chmod(0o700)
+
+
+# ---------- _ensure_secure_dir ----------
+
+
+@posix_only
+def test_ensure_secure_dir_creates_with_0o700_under_strict_umask(tmp_path):
+    """umask masks off bits at mkdir time; the helper must chmod after
+    creating to enforce exactly 0o700."""
+    target = tmp_path / "appfl_root"
+    old_umask = os.umask(0o077)
+    try:
+        _ensure_secure_dir(target)
+    finally:
+        os.umask(old_umask)
+    mode = stat.S_IMODE(target.stat().st_mode)
+    assert mode == 0o700
+
+
+@posix_only
+def test_ensure_secure_dir_repairs_loose_permissions(tmp_path):
+    """If the directory already exists with permissive bits, the helper
+    chmods it back to 0o700 (instead of refusing — the chmod happens
+    before the verify)."""
+    target = tmp_path / "loose"
+    target.mkdir(mode=0o755)
+    _ensure_secure_dir(target)
+    assert stat.S_IMODE(target.stat().st_mode) == 0o700
+
+
+@posix_only
+def test_ensure_secure_dir_refuses_symlink(tmp_path):
+    """A symlink at the path must be refused even if the target is a
+    proper 0o700 directory."""
+    real = tmp_path / "real"
+    real.mkdir(mode=0o700)
+    link = tmp_path / "link"
+    os.symlink(str(real), str(link))
+    with pytest.raises(PermissionError, match="not a directory"):
+        _ensure_secure_dir(link)
+
+
+@posix_only
+def test_ensure_secure_dir_refuses_wrong_owner(tmp_path, monkeypatch):
+    target = tmp_path / "appfl"
+    target.mkdir(mode=0o700)
+    real_uid = os.getuid()
+    monkeypatch.setattr(os, "getuid", lambda: real_uid + 99999)
+    with pytest.raises(PermissionError, match="owned by uid"):
+        _ensure_secure_dir(target)
+
+
+# ---------- legacy bug regression ----------
+
+
+def test_legacy_unsafe_mkdir_not_in_misc_utils():
+    """The duplicated `pathlib.Path(...).mkdir(parents=True, exist_ok=True)`
+    blocks for `.appfl` should be gone from misc.utils — they're replaced by
+    secure_appfl_dir."""
+    import inspect
+    from appfl.misc import utils
+
+    src = inspect.getsource(utils.create_instance_from_file_source)
+    assert "secure_appfl_dir" in src
+    assert "/tmp/.appfl" not in src
+
+
+def test_legacy_unsafe_mkdir_not_in_s3_utils():
+    import inspect
+    from appfl.comm.utils import s3_utils
+
+    src = inspect.getsource(s3_utils)
+    assert "/tmp/.appfl" not in src
+    assert "mkdir(parents=True, exist_ok=True)" not in src
+
+
+def test_legacy_unsafe_mkdir_not_in_s3_storage_init():
+    import inspect
+    from appfl.comm.utils import s3_storage
+
+    src = inspect.getsource(s3_storage.CloudStorage.init)
+    assert "secure_appfl_dir" in src
+    assert "/tmp/.appfl/s3_tmp_dir" not in src


### PR DESCRIPTION
# Description

Stop creating APPFL working directories with umask-derived permissions on
shared hosts.

Six call sites across `src/appfl/comm/utils/s3_utils.py`,
`src/appfl/comm/utils/s3_storage.py`, and `src/appfl/misc/utils.py` were
creating directories under `~/.appfl/` and `/tmp/.appfl/` with:

```python
pathlib.Path(s3_tmp_dir).mkdir(parents=True, exist_ok=True)
```

The `mode=` argument was never set, so each component picked up the
umask-derived default (typically `0o755` — world-readable). Three further
issues compounded this:

1. **Shared `/tmp/.appfl/` fallback** — when `$HOME` is read-only (common in
   containers), the code fell back to a single
   `/tmp/.appfl/...` path. Any local co-tenant could pre-create it and
   later read everything APPFL writes inside.
2. **`exist_ok=True` accepts attacker-pre-created directories** — even if
   the operator's run later succeeds, the directory's mode is whatever the
   pre-creator chose.
3. **`misc.utils.create_instance_from_file_source` /
   `get_function_from_file_source`** write user-supplied Python source into
   `/tmp/.appfl/tmp/<random>.py` and **immediately import it**. A co-tenant
   who pre-creates `/tmp/.appfl/tmp` and watches for new `*.py` files can
   replace one between write and import — local code execution as the
   operator. The umask issue turned this latent footgun into an exploitable
   primitive on every shared host.

## Changes

### `src/appfl/misc/utils.py`

Added two new helpers:

- `_ensure_secure_dir(path)` — creates `path` with mode `0o700` if missing,
  then `os.lstat`s it and refuses if it isn't a real directory (i.e. is a
  symlink), isn't owned by the current uid, or has any group/world bits.
  An explicit `os.chmod(path, 0o700)` runs after the `mkdir` call to defeat
  umask-masking. If the directory pre-existed with looser permissions, the
  helper repairs them rather than failing — but it always refuses on
  symlinks or wrong owner.
- `secure_appfl_dir(*parts) -> str` — builds and returns
  `$HOME/.appfl/<parts...>`, falling back to `/tmp/.appfl-<uid>/<parts...>`
  if the home directory is read-only. The fallback name carries the uid so
  co-tenants cannot collide on a shared `/tmp/.appfl`. Every component from
  the `.appfl(-uid)` root down is run through `_ensure_secure_dir`.

The two `create_*_from_file_source` /
`get_function_from_file_source` helpers in the same file now use
`secure_appfl_dir("tmp")`. The Python source they write therefore lands in
an owner-only directory that no co-tenant can list or replace files in.

### `src/appfl/comm/utils/s3_utils.py`

`send_model_by_pre_signed_s3` and `extract_model_from_s3` previously had
duplicated `try: <home> except: <tmp>` blocks. Both collapse to a single
`s3_tmp_dir = secure_appfl_dir(comm_type, client_id, experiment_id)` call.
The `pathlib` import is removed (no longer needed).

### `src/appfl/comm/utils/s3_storage.py`

`CloudStorage.init` no longer hard-codes `/tmp/.appfl/s3_tmp_dir` as a
fallback. When `s3_tmp_dir` is not supplied, it is now computed via
`secure_appfl_dir("s3_tmp_dir")`, which gives the same home/`/tmp` fallback
behaviour but with the `0o700` enforcement. When the caller supplies an
explicit `s3_tmp_dir`, the value is used as-is (preserving the prior
contract).

## Backwards compatibility

- The `secure_appfl_dir` / `_ensure_secure_dir` helpers are new public/
  private names in `appfl.misc.utils`. No existing names changed.
- Operators whose `~/.appfl/` directory was previously `0o755` (the typical
  default) will see it silently chmodded to `0o700` on the next APPFL run.
  Anything that read those directories from another user account will now
  get `EACCES`, which is the intended behaviour.
- The fallback path moves from `/tmp/.appfl/...` to
  `/tmp/.appfl-<uid>/...`. Operators who scripted around the old literal
  path will need to update those scripts. Nothing in this repository
  references the old literal outside the modules being changed here.
- `CloudStorage.init(s3_tmp_dir=...)` callers that pass an explicit path
  see no behavioural change.

### Fixes

No public GitHub issue is open for this finding.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (internal implementation changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (no changes to the code)
- [ ] CI change (changes to CI workflows, packages, templates, etc.)
- [ ] Version changes (changes to the package or dependency versions)

## Testing

There were no tests covering `secure_appfl_dir`, the `.appfl/`
fallback path, or the `s3_utils` / `s3_storage` directory creation before
this PR. A new file `tests/test_secure_appfl_dir.py` adds 10 tests. All
pass under the project conda env, alongside the 13 pre-existing
`test_s3_credentials_perms.py` tests:

```bash
.conda/bin/python -m pytest tests/test_secure_appfl_dir.py tests/test_s3_credentials_perms.py -v
# 23 passed in 0.81s
```

Cases:

- `test_secure_appfl_dir_uses_home_when_writable` — happy path under a
  monkeypatched `pathlib.Path.home`; every component below `.appfl` is
  `0o700`.
- `test_secure_appfl_dir_falls_back_when_home_unwritable` — when home is
  `0o500` (mkdir fails), the helper falls back to the `/tmp/.appfl-<uid>`
  branch.
- `test_secure_appfl_dir_fallback_namespaced_by_uid` — the fallback path
  contains `.appfl-<uid>` and is **not** the legacy `/tmp/.appfl`. Direct
  regression test for the shared-host info-leak.
- `test_ensure_secure_dir_creates_with_0o700_under_strict_umask` — under
  `umask 0o077` (which would otherwise allow only owner perms anyway) the
  dir is exactly `0o700`. The test guards against regressions if the
  helper ever stops issuing the explicit `os.chmod`.
- `test_ensure_secure_dir_repairs_loose_permissions` — pre-existing
  `0o755` directory is chmodded back to `0o700` by the helper.
- `test_ensure_secure_dir_refuses_symlink` — a symlink at the path raises
  `PermissionError` even when the symlink target is itself a proper
  `0o700` dir. This is the regression test for the symlink-race vector.
- `test_ensure_secure_dir_refuses_wrong_owner` — monkeypatching
  `os.getuid` to a different uid causes the verify step to refuse.
- `test_legacy_unsafe_mkdir_not_in_misc_utils`,
  `_not_in_s3_utils`, and `_not_in_s3_storage_init` — defense-in-depth
  source greps asserting the old literals (`/tmp/.appfl`, raw
  `mkdir(parents=True, exist_ok=True)`) no longer appear in the changed
  call sites.

## Other Pull Request Checklist

- [x] Code changes pass `pre-commit` (e.g., ruff, mypy, etc.) via `pre-commit run --all-files`.
- [x] Tests have been added to show the fix is effective or that the new feature works.
- [x] New and existing unit tests pass locally with the changes.
- [ ] Docs have been updated and reviewed if relevant.