### PR TITLE
Tune keepalive defaults for long-idle FL channels

### DIFF
--- a/src/appfl/comm/grpc/channel.py
+++ b/src/appfl/comm/grpc/channel.py
@@ -38,10 +38,11 @@ def create_grpc_channel(
     channel_options = [
         ("grpc.max_send_message_length", max_message_size),
         ("grpc.max_receive_message_length", max_message_size),
-        ("grpc.keepalive_time_ms", 7200000),
-        ("grpc.keepalive_timeout_ms", 7200000),
-        ("grpc.http2.min_time_between_pings_ms", 7200000),
-        ("grpc.http2.timeout_ms", 7200000),
+        ("grpc.keepalive_time_ms", 30000),
+        ("grpc.keepalive_timeout_ms", 20000),
+        ("grpc.keepalive_permit_without_calls", 1),
+        ("grpc.http2.max_pings_without_data", 0),
+        ("grpc.http2.min_time_between_pings_ms", 10000),
     ]
     if use_ssl:
         if root_certificate is not None:

--- a/src/appfl/comm/grpc/serve.py
+++ b/src/appfl/comm/grpc/serve.py
@@ -63,6 +63,11 @@ def serve(
             ("grpc.max_concurrent_streams", max_workers),
             ("grpc.max_send_message_length", max_message_size),
             ("grpc.max_receive_message_length", max_message_size),
+            ("grpc.keepalive_time_ms", 60000),
+            ("grpc.keepalive_timeout_ms", 20000),
+            ("grpc.keepalive_permit_without_calls", 1),
+            ("grpc.http2.max_pings_without_data", 0),
+            ("grpc.http2.min_ping_interval_without_data_ms", 10000),
         ],
         interceptors=(APPFLAuthMetadataInterceptor(authenticator),)
         if use_authenticator


### PR DESCRIPTION
# Description

Fix the gRPC keepalive defaults so dead peers are detected promptly and
idle channels survive NAT/firewall middleboxes.

The previous defaults — set on every gRPC channel and never set on the
server — were:

```python
("grpc.keepalive_time_ms",                7_200_000),  # 2 h
("grpc.keepalive_timeout_ms",             7_200_000),  # 2 h
("grpc.http2.min_time_between_pings_ms",  7_200_000),  # 2 h
("grpc.http2.timeout_ms",                 7_200_000),  # not a real gRPC option
```

There is no documented rationale for these values: they were introduced in
commit `dcaa9b12` ("rmv communicator module; fix few small issues") with no
comment. The shape (four identical numbers, one of which isn't a valid gRPC
option name) is consistent with someone hitting `GOAWAY: too_many_pings` during
early testing and trying to silencing it in some way.

The values are not just lax — they are actively wrong for the HPC
federated-learning use case APPFL targets. Two failure modes:

1. **Slow-loris / dead-peer DoS.** A client that drops the network (process
   crash, node fence, container kill) holds a worker thread on the server
   for **two hours** before the keepalive timeout reclaims it. With
   `max_workers = 128`, any peer who can open 128 streams and walk away
   wedges the entire server until the legacy 2 h window elapses.

2. **Idle-NAT collapse on long FL rounds.** The HPC pattern is "channel
   sits idle for the duration of a local training step (minutes to hours)
   between rounds." Standard enterprise NAT / firewall middleboxes drop
   idle TCP after 5 – 60 minutes. With keepalive set to 2 hours, a client
   sitting idle for 90 minutes gets its connection silently torn down by
   the network; the next real RPC then hangs on a TCP retransmit timeout
   instead of failing fast. **The fix for "long quiet periods" is shorter
   keepalives, not longer ones** — exactly the inverse of what the legacy
   defaults imply.

The server side had a different bug: it set **no** keepalive options at
all, so even if the client's defaults had been correct, the server would
not have been enforcing anything (and would `GOAWAY` clients that ping
faster than the gRPC default 5-minute floor).

## Changes

### `src/appfl/comm/grpc/channel.py`

Replaced the four legacy values with a sensible client-side keepalive
profile:

```python
("grpc.keepalive_time_ms",                30_000),
("grpc.keepalive_timeout_ms",             20_000),
("grpc.keepalive_permit_without_calls",   1),
("grpc.http2.max_pings_without_data",     0),
("grpc.http2.min_time_between_pings_ms",  10_000),
```

Rationale per knob:

- **`keepalive_time_ms = 30 000`** — send a heartbeat every 30 s. Small
  enough to stay below every NAT idle timeout I'm aware of; large enough
  to add negligible bandwidth (one PING frame every 30 s is ≪ 1 B/s).
- **`keepalive_timeout_ms = 20 000`** — gRPC default; declare the peer
  dead after a 20 s ack window. Closes the slow-loris vector without
  false-positiving over typical WAN jitter.
- **`keepalive_permit_without_calls = 1`** — the HPC pattern is
  "channel sits idle for hours between rounds"; without this flag,
  keepalives are *not* sent during those gaps and the channel still
  rots. This is the single most important option for the HPC use case.
- **`http2.max_pings_without_data = 0`** — "unlimited" pings on an
  otherwise-idle channel; required to actually exercise the keepalive
  during long quiet windows.
- **`http2.min_time_between_pings_ms = 10 000`** — the *peer-side*
  enforcement floor. Must be ≤ the server's
  `min_ping_interval_without_data_ms` or the server will GOAWAY us.

The bogus `http2.timeout_ms` option (not a real gRPC name) is dropped.

### `src/appfl/comm/grpc/serve.py`

The server previously declared no keepalive options. Added the matching
server-side profile:

```python
("grpc.keepalive_time_ms",                              60_000),
("grpc.keepalive_timeout_ms",                           20_000),
("grpc.keepalive_permit_without_calls",                 1),
("grpc.http2.max_pings_without_data",                   0),
("grpc.http2.min_ping_interval_without_data_ms",        10_000),
```

The server's `keepalive_time_ms` is 60 s (twice the client's) so that the
client is normally the one initiating heartbeats; the server's role is
mostly to enforce the rate floor and to detect dead clients on its own
schedule. The `min_ping_interval_without_data_ms` is matched to the
client's `min_time_between_pings_ms` so the two never disagree about
the rate floor.

## Backwards compatibility

- No public API surface changes. Both `create_grpc_channel` and `serve`
  keep their existing signatures.
- Operators who previously relied on the 2 h keepalive timeout to keep
  unreachable peers in the worker pool (unlikely, but possible) will see
  those peers reclaimed in 20 s instead. This is the intended outcome.
- Channels that pass `**kwargs` through `create_grpc_channel` are
  unaffected — the function does not accept overrides for the keepalive
  options today, so there is no upstream caller silently overriding them.

### Fixes

No public GitHub issue is open for this finding.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (internal implementation changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (no changes to the code)
- [ ] CI change (changes to CI workflows, packages, templates, etc.)
- [ ] Version changes (changes to the package or dependency versions)

## Testing

The change is configuration-only and cannot be exercised meaningfully by
the existing MPI-driven test suite (which never opens a gRPC channel that
sits idle long enough for keepalives to matter). The single existing gRPC
test (`tests/test_mnist.py::test_grpc`) continues to pass because the new
values do not affect happy-path round trips.

A behavioural test would require a real long-idle gRPC channel through a
real NAT-like middlebox; that is out of scope for unit tests and belongs
in an HPC integration suite.

## Other Pull Request Checklist

- [x] Code changes pass `pre-commit` (e.g., ruff, mypy, etc.) via `pre-commit run --all-files`.
- [ ] Tests have been added to show the fix is effective or that the new feature works.
- [x] New and existing unit tests pass locally with the changes.
- [ ] Docs have been updated and reviewed if relevant.