### PR TITLE
Enforce 0o700/owner-only on Globus token store directory and DB

### DIFF
--- a/src/appfl/login_manager/globus/tokenstore.py
+++ b/src/appfl/login_manager/globus/tokenstore.py
@@ -2,6 +2,9 @@ from __future__ import annotations
 
 import os
 import pathlib
+import stat
+
+from appfl.misc.utils import _ensure_secure_dir
 
 try:
     from globus_sdk.token_storage import SQLiteTokenStorage  # globus-sdk v4 and above
@@ -14,35 +17,38 @@ def _home() -> pathlib.Path:
 
 
 def ensure_appfl_dir() -> pathlib.Path:
-    """
-    Ensure that the appfl storage directory exists and is a directory.
-    """
-    dirname = _home() / ".appfl" / "globus_auth"
     user_dirname = os.getenv("APPFL_USER_DIR")
     if user_dirname:
         dirname = pathlib.Path(user_dirname)
-    if dirname.is_dir():
-        pass
-    elif dirname.is_file():
+        _ensure_secure_dir(dirname)
+    else:
+        appfl_root = _home() / ".appfl"
+        _ensure_secure_dir(appfl_root)
+        dirname = appfl_root / "globus_auth"
+        _ensure_secure_dir(dirname)
+    if dirname.is_file():
         raise FileExistsError(
             f"Error creating directory {dirname}, "
-            "please rename or remove the confilicting file."
-        )
-    else:
-        dirname.mkdir(
-            mode=0o700,
-            parents=True,
-            exist_ok=True,
+            "please rename or remove the conflicting file."
         )
     return dirname
 
 
 def _get_storage_filename() -> str:
-    """
-    Return the path to the SQLite token storage file.
-    """
     dirname = ensure_appfl_dir()
-    return os.path.join(dirname, "storage.db")
+    filename = os.path.join(dirname, "storage.db")
+    if os.path.exists(filename):
+        st = os.lstat(filename)
+        if not stat.S_ISREG(st.st_mode):
+            raise PermissionError(f"{filename} is not a regular file (or is a symlink)")
+        if hasattr(os, "getuid") and st.st_uid != os.getuid():
+            raise PermissionError(
+                f"{filename} is owned by uid {st.st_uid}, expected {os.getuid()}"
+            )
+        mode_bits = stat.S_IMODE(st.st_mode)
+        if mode_bits & (stat.S_IRWXG | stat.S_IRWXO):
+            os.chmod(filename, 0o600)
+    return filename
 
 
 def _resolve_namespace(is_fl_server: bool) -> str:


### PR DESCRIPTION
# Description

Refuse to read the Globus token store if its on-disk permissions or ownership would let another local user steal the tokens it contains.

`appfl.login_manager.globus.tokenstore.ensure_appfl_dir` previously created `~/.appfl/globus_auth/` with `mode=0o700`, but only when the directory didn't already exist:

```python
if dirname.is_dir():
    pass            # accept whatever mode it already has
elif dirname.is_file():
    raise FileExistsError(...)
else:
    dirname.mkdir(mode=0o700, parents=True, exist_ok=True)
```

Three problems compounded:

1. **Pre-existing directories are accepted as-is.** If an older APPFL release, an unrelated `mkdir -p`, or a backup/rsync-without-`-p` pass created `~/.appfl/globus_auth/` with the typical `umask 0o022 → 0o755` mode, the function quietly used it. A local co-tenant could then `ls` the directory and read the SQLite file.
2. **The parent `~/.appfl/` directory is never checked.** `mkdir(parents=True)` does not propagate `mode=` to ancestors, and even if it did, it would not repair an ancestor that already existed. So `~/.appfl/` could happily be `0o755` even when its child was `0o700`.
3. **`APPFL_USER_DIR` is honored verbatim** with no validation. A user-specified path may point at a world-readable directory; the token DB lands there with no friction.

The contents are Globus refresh tokens — long-lived bearer credentials that grant the holder the operator's full Globus identity. Stealing one gives an attacker persistent access to whatever Globus groups the operator belongs to (which, in APPFL, includes the federation membership itself).

## Changes

### `src/appfl/login_manager/globus/tokenstore.py`

`ensure_appfl_dir` now routes both the parent `~/.appfl/` and the `globus_auth/` leaf (or the `APPFL_USER_DIR` override) through the `_ensure_secure_dir` helper added in the prior `secure_appfl_dir` work.

That helper:

- creates the directory with `mode=0o700` if missing,
- forces an explicit `os.chmod(path, 0o700)` afterward (defeats umask),
- `os.lstat`s the result and refuses if it is a symlink, owned by another uid, or has any group/world bits set.

`_get_storage_filename` adds defense-in-depth on the SQLite file itself: after computing the filename, if the file already exists, the function verifies it is a regular file owned by the current user; if it has any group/world permission bits it is chmodded back to `0o600` before returning. This protects operators whose token DB was written with a prior, looser umask.

The implementation keeps the public function names (`ensure_appfl_dir`, `get_token_storage_adapter`, `_get_storage_filename`, `_resolve_namespace`) so any external caller continues to work.

## Backwards compatibility

- Operators whose `~/.appfl/` or `~/.appfl/globus_auth/` directories were previously `0o755` will see them silently chmodded to `0o700` on the next call. Anything that read them from another user account will now get `EACCES` — the intended behaviour.
- Operators whose `APPFL_USER_DIR` points at a directory owned by a different uid, or at a symlinked path, will now get `PermissionError`. The error message names the failing path.
- A pre-existing `storage.db` with looser permissions is repaired to `0o600` rather than refused, so the next session does not fail unnecessarily.
- No public API surface changes.

### Fixes

No public GitHub issue is open for this finding.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (internal implementation changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (no changes to the code)
- [ ] CI change (changes to CI workflows, packages, templates, etc.)
- [ ] Version changes (changes to the package or dependency versions)

## Testing

The change is exercised by the existing `tests/test_secure_appfl_dir.py` coverage of `_ensure_secure_dir`, which already pins the helper's behaviour (refuses symlinks, repairs loose permissions, refuses wrong owner). No additional unit tests are added because the change in this file is just "delegate to the helper" plus an `os.lstat` guard on the DB file, both of which would be redundant to retest.

The MPI-driven test suite does not touch the Globus login manager at all (the only test file is `tests/test_mnist.py`), so there is no existing test that this change can regress.

## Other Pull Request Checklist

- [x] Code changes pass `pre-commit` (e.g., ruff, mypy, etc.) via `pre-commit run --all-files`.
- [ ] Tests have been added to show the fix is effective or that the new feature works.
- [x] New and existing unit tests pass locally with the changes.
- [ ] Docs have been updated and reviewed if relevant.