### PR TITLE
Fixing FedQueue Logics and logging

### DIFF
--- a/examples/resources/configs/mnist/server_fedqueue.yaml
+++ b/examples/resources/configs/mnist/server_fedqueue.yaml
@@ -48,6 +48,17 @@ server_configs:
     alpha_compute: 0.5
     safety_buffer: 0.5
     admission_tolerance: 0.15
+    simulate_queue: false
+    log_fedqueue_metrics: false
+    q_init: 2.0
+    alpha_admission: 0.2
+    beta_queue: 0.2
+    theta: 0.5
+    queue_mode: "lognormal"
+    queue_means: "1.5,2.0"
+    queue_sigma: 0.4
+    slowdown: "1.0,1.0"
+    fedqueue_log_dir: "./output"
   aggregator: "FedQueueAggregator"
   aggregator_kwargs:
     staleness_fn: "harmonic"

--- a/src/appfl/algorithm/aggregator/fedqueue_aggregator.py
+++ b/src/appfl/algorithm/aggregator/fedqueue_aggregator.py
@@ -72,12 +72,7 @@ class FedQueueAggregator(BaseAggregator):
 
         gradient_based = self.aggregator_configs.get("gradient_based", False)
 
-        local_step_sum = sum(local_steps.values())
-        aggregation_factors = {
-            client_id: self.staleness_fn(staleness[client_id])
-            * (local_steps[client_id] / local_step_sum)
-            for client_id in local_steps
-        }
+        aggregation_factors = self._get_aggregation_factors(local_models, staleness)
         aggregation_factor_sum = sum(aggregation_factors.values())
         aggregation_factors = {
             client_id: factor / aggregation_factor_sum
@@ -139,6 +134,39 @@ class FedQueueAggregator(BaseAggregator):
             self.model.load_state_dict(self.global_state, strict=False)
 
         return clone_state_dict_optimized(self.global_state)
+
+    def _get_aggregation_factors(
+        self,
+        local_models: Dict[Union[str, int], Union[Dict, OrderedDict]],
+        staleness: Dict[Union[str, int], int],
+    ) -> Dict[Union[str, int], float]:
+        """
+        FedQueue uses data-size client weights and staleness decay. Local steps
+        only affect client-side work and learning-rate scaling, not aggregation.
+        """
+        if hasattr(self, "client_sample_size") and all(
+            client_id in self.client_sample_size for client_id in local_models
+        ):
+            total_sample_size = sum(
+                self.client_sample_size[client_id] for client_id in local_models
+            )
+            if total_sample_size > 0:
+                return {
+                    client_id: self.staleness_fn(staleness[client_id])
+                    * (self.client_sample_size[client_id] / total_sample_size)
+                    for client_id in local_models
+                }
+
+        if self.logger is not None:
+            self.logger.warning(
+                "FedQueueAggregator did not receive sample sizes for all "
+                "participating clients; falling back to equal client weights."
+            )
+        return {
+            client_id: self.staleness_fn(staleness[client_id])
+            * (1.0 / len(local_models))
+            for client_id in local_models
+        }
 
     def get_parameters(self, **kwargs) -> Dict:
         if self.global_state is None:

--- a/src/appfl/algorithm/scheduler/queue_scheduler.py
+++ b/src/appfl/algorithm/scheduler/queue_scheduler.py
@@ -1,5 +1,8 @@
 import time
 import math
+import csv
+import os
+import random
 import threading
 from omegaconf import DictConfig
 from collections import OrderedDict
@@ -30,6 +33,28 @@ class QueueScheduler(BaseScheduler):
         self.admission_tolerance = self.scheduler_configs.get(
             "admission_tolerance", 0.15
         )
+        self.simulate_queue = self.scheduler_configs.get("simulate_queue", False)
+        self.log_fedqueue_metrics = self.scheduler_configs.get(
+            "log_fedqueue_metrics", False
+        )
+        self.q_init = self.scheduler_configs.get("q_init", 2.0)
+        self.alpha_admission = self.scheduler_configs.get("alpha_admission", 0.2)
+        self.beta_queue = self.scheduler_configs.get("beta_queue", self.alpha_queue)
+        self.theta = self.scheduler_configs.get("theta", self.safety_buffer)
+        self.queue_mode = str(
+            self.scheduler_configs.get("queue_mode", "lognormal")
+        ).lower()
+        self.queue_sigma = self.scheduler_configs.get("queue_sigma", 0.4)
+        self.queue_means = self._parse_float_list(
+            self.scheduler_configs.get("queue_means", self.q_init)
+        )
+        self.queue_fixed = self._parse_float_list(
+            self.scheduler_configs.get("queue_fixed", self.q_init)
+        )
+        self.slowdown = self._parse_float_list(
+            self.scheduler_configs.get("slowdown", 1.0)
+        )
+        self._queue_rng = random.Random(self.scheduler_configs.get("queue_seed", 0))
         self._access_lock = threading.Lock()
         self.future_record = {}
         self.timer_record = None
@@ -37,7 +62,12 @@ class QueueScheduler(BaseScheduler):
         self.client_steps_record = {}
         self.queue_time_estimation = {}
         self.compute_time_estimation = {}
+        self.client_deadline_record = {}
+        self.round_start_record = {}
+        self.late_client_model_buffer = []
+        self._fedqueue_log_paths = None
         self._reset_client_model_buffer()
+        self._init_fedqueue_logs()
 
     def get_parameters(
         self, **kwargs
@@ -58,20 +88,58 @@ class QueueScheduler(BaseScheduler):
         **kwargs,
     ) -> Future:
         with self._access_lock:
+            queue_prior = self.queue_time_estimation.get(client_id, self.q_init)
             self._update_queue_estimation(client_id, kwargs)
             self._update_compute_estimation(client_id, kwargs)
-            self.client_model_buffer["local_models"][client_id] = local_model
-            self.client_model_buffer["local_steps"][client_id] = self._get_local_steps(
-                client_id
-            )
-            self.client_model_buffer["curr_round"][client_id] = self._get_curr_round(
-                client_id
-            )
             future = Future()
             self.future_record[client_id] = future
-            if len(self.client_model_buffer["local_models"]) == self.num_clients:
+            kwargs["queue_prior"] = queue_prior
+            self._schedule_update_with_admission(client_id, local_model, kwargs)
+            if self._should_aggregate(lock_acquired=True):
                 self._aggregate_global_model(lock_acquired=True)
             return future
+
+    def _schedule_update_with_admission(
+        self,
+        client_id: Union[int, str],
+        local_model: Union[Dict, OrderedDict],
+        kwargs: Dict,
+    ) -> None:
+        curr_round = self._get_curr_round(client_id)
+        q_delay = kwargs.get("queue_delay", kwargs.get("queue_time", 0.0))
+        q_hat = kwargs.get("queue_prior", self.queue_time_estimation[client_id])
+        deadline = self.client_deadline_record.get(
+            client_id,
+            q_hat + self.alpha_admission * self.t_sync,
+        )
+        admitted = q_delay <= deadline
+        arrival_offset = time.time() - self.round_start_record.get(
+            client_id, time.time()
+        )
+        entry = {
+            "client_id": client_id,
+            "local_model": local_model,
+            "local_steps": self._get_local_steps(client_id),
+            "curr_round": curr_round,
+            "q_delay": q_delay,
+            "q_hat": q_hat,
+            "deadline": deadline,
+            "Jk": self._get_job_budget_from_queue_estimate(q_hat),
+            "arrival_offset": arrival_offset,
+        }
+        if admitted:
+            self.client_model_buffer["local_models"][client_id] = local_model
+            self.client_model_buffer["local_steps"][client_id] = entry["local_steps"]
+            self.client_model_buffer["curr_round"][client_id] = curr_round
+            self.client_model_buffer["q_delay"][client_id] = q_delay
+            self.client_model_buffer["q_hat"][client_id] = entry["q_hat"]
+            self.client_model_buffer["deadline"][client_id] = deadline
+            self.client_model_buffer["arrival_offset"][client_id] = arrival_offset
+        else:
+            self.late_client_model_buffer.append(entry)
+        self._log_round_row(client_id, admitted, entry)
+        if self.timer_record is None:
+            self._start_aggregation_timer()
 
     def _aggregate_global_model(
         self,
@@ -85,9 +153,16 @@ class QueueScheduler(BaseScheduler):
         if not lock_acquired:
             self._access_lock.acquire()
 
-        all_clients = list(self.client_model_buffer["local_models"].keys())
+        self._merge_carry_over_clients()
 
-        if len(all_clients) > 0:
+        all_clients = list(self.client_model_buffer["local_models"].keys())
+        late_clients = [entry["client_id"] for entry in self.late_client_model_buffer]
+
+        if len(all_clients) > 0 or len(self.late_client_model_buffer) > 0:
+            if len(all_clients) == 0:
+                self._use_late_updates_if_no_admitted_updates()
+                all_clients = list(self.client_model_buffer["local_models"].keys())
+
             self.logger.info(
                 f"[FedQueue Scheduler][Global Round {self.global_round + 1}] Aggregating global model for clients: {list(self.client_model_buffer['local_models'].keys())} {'(Triggered by timer)' if not lock_acquired else ''}"
             )
@@ -99,10 +174,9 @@ class QueueScheduler(BaseScheduler):
             global_model = self.aggregator.aggregate(
                 local_models=self.client_model_buffer["local_models"],
                 staleness=staleness,
-                local_steps=self.client_model_buffer[
-                    "local_steps"
-                ],  # check this for computing p_k
+                local_steps=self.client_model_buffer["local_steps"],
             )
+            self._log_applied_rows(all_clients, staleness)
             self.global_round += 1
             self._num_global_epochs += 1
             for client_id in all_clients:
@@ -113,16 +187,62 @@ class QueueScheduler(BaseScheduler):
                 self.client_round_record[client_id] = self.global_round
                 del self.future_record[client_id]
             self._reset_client_model_buffer()
-
-            self.timer_record = threading.Timer(
-                (1 + self.admission_tolerance) * self.t_sync,
-                self._aggregate_global_model,
-                kwargs={"lock_acquired": False},
+            self._log_detail(
+                f"[Round {self.global_round}] admitted={all_clients}; "
+                f"late_buffer={late_clients}"
             )
-            self.timer_record.start()
+
+            self._start_aggregation_timer()
 
         if not lock_acquired:
             self._access_lock.release()
+
+    def _should_aggregate(self, lock_acquired: bool) -> bool:
+        admitted_count = len(self.client_model_buffer["local_models"])
+        arrived_count = admitted_count + len(self.late_client_model_buffer)
+        return lock_acquired and arrived_count >= self.num_clients
+
+    def _use_late_updates_if_no_admitted_updates(self) -> None:
+        for entry in self.late_client_model_buffer:
+            client_id = entry["client_id"]
+            self.client_model_buffer["local_models"][client_id] = entry["local_model"]
+            self.client_model_buffer["local_steps"][client_id] = entry["local_steps"]
+            self.client_model_buffer["curr_round"][client_id] = entry["curr_round"]
+            self.client_model_buffer["q_delay"][client_id] = entry["q_delay"]
+            self.client_model_buffer["q_hat"][client_id] = entry["q_hat"]
+            self.client_model_buffer["deadline"][client_id] = entry["deadline"]
+            self.client_model_buffer["arrival_offset"][client_id] = entry[
+                "arrival_offset"
+            ]
+        self.late_client_model_buffer = []
+
+    def _merge_carry_over_clients(self) -> None:
+        retained_late_clients = []
+        for entry in self.late_client_model_buffer:
+            if entry["curr_round"] >= self.global_round:
+                retained_late_clients.append(entry)
+                continue
+            client_id = entry["client_id"]
+            self.client_model_buffer["local_models"][client_id] = entry["local_model"]
+            self.client_model_buffer["local_steps"][client_id] = entry["local_steps"]
+            self.client_model_buffer["curr_round"][client_id] = entry["curr_round"]
+            self.client_model_buffer["q_delay"][client_id] = entry["q_delay"]
+            self.client_model_buffer["q_hat"][client_id] = entry["q_hat"]
+            self.client_model_buffer["deadline"][client_id] = entry["deadline"]
+            self.client_model_buffer["arrival_offset"][client_id] = entry[
+                "arrival_offset"
+            ]
+        self.late_client_model_buffer = retained_late_clients
+
+    def _start_aggregation_timer(self) -> None:
+        if self.timer_record is not None:
+            self.timer_record.cancel()
+        self.timer_record = threading.Timer(
+            (1 + self.admission_tolerance) * self.t_sync,
+            self._aggregate_global_model,
+            kwargs={"lock_acquired": False},
+        )
+        self.timer_record.start()
 
     def _update_queue_estimation(
         self,
@@ -130,12 +250,12 @@ class QueueScheduler(BaseScheduler):
         kwargs: Dict,
     ) -> None:
         assert "queue_time" in kwargs, "QueueScheduler requires `queue_time` in kwargs."
-        queue_time = kwargs["queue_time"]
+        queue_time = kwargs.get("queue_delay", kwargs["queue_time"])
         if client_id not in self.queue_time_estimation:
-            self.queue_time_estimation[client_id] = queue_time
+            self.queue_time_estimation[client_id] = self.q_init
         self.queue_time_estimation[client_id] = (
-            self.alpha_queue * queue_time
-            + (1 - self.alpha_queue) * self.queue_time_estimation[client_id]
+            self.beta_queue * queue_time
+            + (1 - self.beta_queue) * self.queue_time_estimation[client_id]
         )
         self.logger.debug(
             f"Updated queue time estimation for client {client_id}: {self.queue_time_estimation[client_id]}"
@@ -172,27 +292,33 @@ class QueueScheduler(BaseScheduler):
             "local_models": {},
             "local_steps": {},
             "curr_round": {},
+            "q_delay": {},
+            "q_hat": {},
+            "deadline": {},
+            "arrival_offset": {},
         }
 
     def _get_client_metadata(
         self, client_id: Union[int, str], all_clients: List[Union[int, str]]
     ) -> Dict[str, Any]:
-        job_budget = (
-            self.t_sync - self.queue_time_estimation[client_id] - self.safety_buffer
-        )
+        q_hat = self.queue_time_estimation.get(client_id, self.q_init)
+        job_budget = self._get_job_budget_from_queue_estimate(q_hat)
         local_steps = max(
             math.floor(job_budget / self.compute_time_estimation[client_id]),
             self.warm_up_steps,
         )
+        step_clients = list(self.compute_time_estimation.keys())
         all_local_steps = [
             max(
                 math.floor(
-                    (self.t_sync - self.queue_time_estimation[cid] - self.safety_buffer)
+                    self._get_job_budget_from_queue_estimate(
+                        self.queue_time_estimation.get(cid, self.q_init)
+                    )
                     / self.compute_time_estimation[cid]
                 ),
                 self.warm_up_steps,
             )
-            for cid in all_clients
+            for cid in step_clients
         ]
         min_local_steps = min(all_local_steps)
         learning_rate = self.lr_base * (min_local_steps / local_steps)
@@ -202,6 +328,161 @@ class QueueScheduler(BaseScheduler):
             "learning_rate": learning_rate,
             "start_time": time.time(),
         }
+        deadline = q_hat + self.alpha_admission * self.t_sync
+        self.client_deadline_record[client_id] = deadline
+        self.round_start_record[client_id] = client_metadata["start_time"]
+        if self.simulate_queue:
+            queue_delay = self._sample_queue_delay(client_id)
+            client_metadata.update(
+                {
+                    "queue_delay": queue_delay,
+                }
+            )
+        client_metadata.update(
+            {
+                "slowdown": self._get_indexed_value(self.slowdown, client_id, 1.0),
+                "origin_round": self.global_round,
+            }
+        )
+        self._log_detail(
+            f"client={client_id} q_hat={q_hat:.6f} "
+            f"deadline={deadline:.6f} "
+            f"local_steps={local_steps} learning_rate={learning_rate:.8f}"
+        )
         self.logger.debug(f"Client {client_id} metadata: {client_metadata}")
         self.client_steps_record[client_id] = local_steps
         return client_metadata
+
+    def _get_job_budget_from_queue_estimate(self, q_hat: float) -> float:
+        return max(0.5, self.t_sync - q_hat - self.theta)
+
+    def _sample_queue_delay(self, client_id: Union[int, str]) -> float:
+        if self.queue_mode == "off":
+            return 0.0
+        if self.queue_mode == "fixed":
+            return max(0.0, self._get_indexed_value(self.queue_fixed, client_id, 0.0))
+        mean = max(
+            1e-6, self._get_indexed_value(self.queue_means, client_id, self.q_init)
+        )
+        sigma = float(self.queue_sigma)
+        mu = math.log(mean) - 0.5 * sigma * sigma
+        return max(0.0, self._queue_rng.lognormvariate(mu, sigma))
+
+    def _get_indexed_value(
+        self, values: List[float], client_id: Union[int, str], default: float
+    ) -> float:
+        if len(values) == 0:
+            return default
+        idx = self._client_index(client_id)
+        if idx < len(values):
+            return values[idx]
+        return values[-1]
+
+    def _client_index(self, client_id: Union[int, str]) -> int:
+        try:
+            return int(client_id) - 1
+        except (TypeError, ValueError):
+            digits = "".join(ch for ch in str(client_id) if ch.isdigit())
+            if digits:
+                return max(0, int(digits) - 1)
+        return 0
+
+    def _parse_float_list(self, value: Any) -> List[float]:
+        if isinstance(value, (list, tuple)):
+            return [float(v) for v in value]
+        return [float(v.strip()) for v in str(value).split(",") if v.strip()]
+
+    def _init_fedqueue_logs(self) -> None:
+        if not self.log_fedqueue_metrics:
+            return
+        outdir = self.scheduler_configs.get("fedqueue_log_dir", "./output")
+        log_dir = os.path.join(str(outdir), "logs")
+        os.makedirs(log_dir, exist_ok=True)
+        self._fedqueue_log_paths = {
+            "rounds": os.path.join(log_dir, "fedqueue_rounds.csv"),
+            "applied": os.path.join(log_dir, "fedqueue_applied.csv"),
+            "detail": os.path.join(log_dir, "fedqueue.log"),
+        }
+        with open(self._fedqueue_log_paths["rounds"], "w", newline="") as f:
+            csv.writer(f).writerow(
+                [
+                    "round",
+                    "cid",
+                    "admitted",
+                    "q_delay",
+                    "q_hat",
+                    "deadline",
+                    "Jk",
+                    "Ek",
+                    "Emin",
+                    "eta_k",
+                    "arrival_offset",
+                ]
+            )
+        with open(self._fedqueue_log_paths["applied"], "w", newline="") as f:
+            csv.writer(f).writerow(
+                ["round_applied", "cid", "origin_round", "staleness", "p_k"]
+            )
+        open(self._fedqueue_log_paths["detail"], "w").close()
+
+    def _log_round_row(
+        self, client_id: Union[int, str], admitted: bool, entry: Dict
+    ) -> None:
+        if self._fedqueue_log_paths is None:
+            return
+        local_steps = entry["local_steps"]
+        all_steps = list(self.client_steps_record.values()) or [local_steps]
+        min_steps = min(all_steps)
+        eta = self.lr_base * (min_steps / local_steps)
+        with open(self._fedqueue_log_paths["rounds"], "a", newline="") as f:
+            csv.writer(f).writerow(
+                [
+                    self.global_round + 1,
+                    client_id,
+                    int(admitted),
+                    round(float(entry["q_delay"]), 6),
+                    round(float(entry["q_hat"]), 6),
+                    round(float(entry["deadline"]), 6),
+                    round(float(entry["Jk"]), 6),
+                    int(local_steps),
+                    int(min_steps),
+                    round(float(eta), 8),
+                    round(float(entry["arrival_offset"]), 6),
+                ]
+            )
+
+    def _log_applied_rows(
+        self, all_clients: List[Union[int, str]], staleness: Dict[Union[str, int], int]
+    ) -> None:
+        if self._fedqueue_log_paths is None:
+            return
+        sample_sizes = getattr(self.aggregator, "client_sample_size", {})
+        total_sample_size = sum(sample_sizes.values()) if sample_sizes else 0
+        with open(self._fedqueue_log_paths["applied"], "a", newline="") as f:
+            writer = csv.writer(f)
+            for client_id in all_clients:
+                p_k = (
+                    sample_sizes.get(client_id, 0) / total_sample_size
+                    if total_sample_size > 0
+                    else 1.0 / len(all_clients)
+                )
+                writer.writerow(
+                    [
+                        self.global_round + 1,
+                        client_id,
+                        self.client_model_buffer["curr_round"][client_id],
+                        staleness[client_id],
+                        round(float(p_k), 8),
+                    ]
+                )
+
+    def _log_detail(self, message: str) -> None:
+        if self._fedqueue_log_paths is None:
+            return
+        with open(self._fedqueue_log_paths["detail"], "a") as f:
+            f.write(message + "\n")
+
+    def clean_up(self) -> None:
+        if self.timer_record is not None:
+            self.timer_record.cancel()
+            self.timer_record = None

--- a/src/appfl/algorithm/trainer/vanilla_trainer.py
+++ b/src/appfl/algorithm/trainer/vanilla_trainer.py
@@ -106,6 +106,8 @@ class VanillaTrainer(BaseTrainer):
         Train the model for a certain number of local epochs or steps and store the mode state
         (probably with perturbation for differential privacy) in `self.model_state`.
         """
+        if "queue_delay" in kwargs:
+            time.sleep(max(0.0, float(kwargs["queue_delay"])))
         if "local_steps" in kwargs:
             self.train_configs.num_local_steps = kwargs["local_steps"]
         if "learning_rate" in kwargs:
@@ -116,6 +118,10 @@ class VanillaTrainer(BaseTrainer):
 
         if "start_time" in kwargs:
             self.val_results["queue_time"] = time.time() - kwargs["start_time"]
+        if "queue_delay" in kwargs:
+            self.val_results["queue_delay"] = kwargs["queue_delay"]
+        if "origin_round" in kwargs:
+            self.val_results["origin_round"] = kwargs["origin_round"]
 
         # Store the previous model state for gradient computation
         send_gradient = self.train_configs.get("send_gradient", False)
@@ -328,6 +334,10 @@ class VanillaTrainer(BaseTrainer):
                 self.val_results["val_loss"] = val_loss
                 self.val_results["val_accuracy"] = val_accuracy
             per_step_time = time.time() - start_time
+            if "slowdown" in kwargs and float(kwargs["slowdown"]) > 1.0:
+                slow_padding = per_step_time * (float(kwargs["slowdown"]) - 1.0)
+                time.sleep(slow_padding)
+                per_step_time += slow_padding
             self.val_results["compute_second_per_step"] = (
                 per_step_time / self.train_configs.num_local_steps
             )


### PR DESCRIPTION
# Description
The PR contains the following modifications to make the implementation aligned with the FedQueue algorithm:

- **Admission based aggregation:** The fix in here ensures the creation of the active set, comparing the observed queue delay values of the clients with the cut off threshold. The server will aggregate as soon as the clients included in the active set arrives or the aggression timer is triggered. It can accommodate the scenario of, if no client arrives within the aggregation timer, in that case it will do the aggregation on the updates from the carry over pool.
- **Staleness logic is fixed:** According to the FedQueue paper the staleness will be calculated based on how many aggregation rounds a client has missed. This logic is fixed now.
- **Optional lognormal based queue delay simulation:** One can make the 'simulate_queue' flag in the `server_fedqueue.yaml` file as true and they can simulate the queue delay sampled from a lognormal distribution. This flag can be used to reproduce the results reported in the FedQueue paper simulation section.
- **Comprehensive logging:** The logging procedure is made comprehensive to capture all the hyperparameter values, round time, staleness factor and will be logged at the server side, aligned with APPFL's logging format. This comprehensive logging can be enabled making the `log_fedqueue_metrics` to true.