### PR TITLE
Validate incoming gRPC model payloads against the server's known state-dict schema, and avoid weight_only=False

### DIFF
--- a/src/appfl/agent/server.py
+++ b/src/appfl/agent/server.py
@@ -19,6 +19,7 @@ from appfl.misc.utils import (
     get_appfl_compressor,
     get_appfl_scheduler,
 )
+from appfl.comm.utils.state_dict_validation import validate_state_dict
 from concurrent.futures import Future
 from torch.utils.data import DataLoader
 from omegaconf import OmegaConf, DictConfig
@@ -496,16 +497,33 @@ class ServerAgent:
             )
 
     def _bytes_to_model(self, model_bytes: bytes) -> Union[Dict, OrderedDict]:
-        """Deserialize the model from bytes."""
+        """Deserialize and validate the model from bytes.
+
+        Two layers of defence:
+
+        1. ``torch.load(..., weights_only=True)`` — refuses any payload that
+           is not torch's pickle subset, so a gadget cannot execute Python
+           during deserialisation.
+        2. :func:`validate_state_dict` — enforces APPFL's actual schema: the
+           payload must be a ``Mapping[str, torch.Tensor]`` whose keys and
+           per-tensor shape/dtype match ``self.model.state_dict()``. Anything
+           else is rejected before it reaches the aggregator.
+        """
         if not self.enable_compression:
             # Memory optimization: Use context manager and load to CPU first
             if self.optimize_memory:
                 with io.BytesIO(model_bytes) as buffer:
-                    model = torch.load(buffer, map_location="cpu")
+                    model = torch.load(buffer, map_location="cpu", weights_only=True)
                 gc.collect()
-                return model
             else:
-                return torch.load(io.BytesIO(model_bytes))
+                model = torch.load(io.BytesIO(model_bytes), weights_only=True)
+            reference = (
+                self.model.state_dict()
+                if getattr(self, "model", None) is not None
+                else None
+            )
+            validate_state_dict(model, reference=reference)
+            return model
         else:
             if self.model is None:
                 raise ValueError(

--- a/src/appfl/comm/grpc/grpc_client_communicator.py
+++ b/src/appfl/comm/grpc/grpc_client_communicator.py
@@ -640,10 +640,16 @@ class GRPCClientCommunicator:
         return serialized_data
 
     def _deserialize_model_optimized(self, model_bytes):
-        """Memory-efficient model deserialization."""
+        """Memory-efficient model deserialization.
+
+        Uses ``weights_only=True`` so a malicious payload cannot execute
+        Python during ``torch.load``. The threat model treats the server as
+        trusted, but defense-in-depth here is free: the global model is a
+        tensor state dict in every legitimate code path.
+        """
         with io.BytesIO(model_bytes) as buffer:
             model = torch.load(
-                buffer, map_location="cpu"
+                buffer, map_location="cpu", weights_only=True
             )  # Load to CPU first for memory efficiency
         gc.collect()
         return model

--- a/src/appfl/comm/grpc/grpc_server_communicator.py
+++ b/src/appfl/comm/grpc/grpc_server_communicator.py
@@ -32,6 +32,7 @@ from .grpc_communicator_pb2_grpc import GRPCCommunicatorServicer
 from appfl.agent import ServerAgent
 from appfl.logger import ServerAgentFileLogger
 from appfl.misc.utils import deserialize_yaml, get_proxystore_connector
+from appfl.comm.utils.state_dict_validation import validate_state_dict
 from .utils import proto_to_databuffer, serialize_model, deserialize_model
 from appfl.misc.memory_utils import (
     efficient_bytearray_concatenation,
@@ -61,6 +62,7 @@ class GRPCServerCommunicator(GRPCCommunicatorServicer):
         )
         self._load_proxystore(server_agent.server_agent_config)
         self._load_google_drive(server_agent.server_agent_config)
+        self._load_s3_flag(server_agent.server_agent_config)
         self._num_connected_clients = 0
         self._total_num_clients = self.server_agent.get_num_clients()
 
@@ -156,6 +158,9 @@ class GRPCServerCommunicator(GRPCCommunicatorServicer):
             model_key = None
             model_url = None
             if use_s3:
+                self._require_server_feature(
+                    "_use_s3", self.use_s3bucket, request.header.client_id, context
+                )
                 model_key = meta_data.get("model_key", None)
                 model_url = meta_data.get("model_url", None)
 
@@ -323,19 +328,42 @@ class GRPCServerCommunicator(GRPCCommunicatorServicer):
                     or self.kwargs.get("use_authenticator", False),
                     warning_message="Loading metadata fails due to untrusted data in the metadata, you can fix this by setting `trusted=True` in `grpc_configs` or use an authenticator.",
                 )
+            # The three alternative-transport branches below all eventually
+            # produce a tensor state dict, which is then schema-validated
+            # against the server's own model. The reference object that
+            # *describes* where to fetch the state dict differs by transport:
+            #
+            # * colab and S3 use a plain Python dict, which round-trips safely
+            #   through torch.load(weights_only=True);
+            # * proxystore uses a Proxy class with a user-defined factory,
+            #   which forces weights_only=False — that branch is therefore
+            #   gated by the server-side proxystore-enabled flag so an
+            #   unauthorised client cannot trigger it.
             if meta_data.get("_use_proxystore", False):
-                local_model_proxy = deserialize_model(local_model)
+                self._require_server_feature(
+                    "_use_proxystore", self.use_proxystore, client_id, context
+                )
+                local_model_proxy = deserialize_model(local_model, weights_only=False)
                 local_model = extract(local_model_proxy)
 
                 if self.optimize_memory:
                     optimize_memory_cleanup(local_model_proxy, force_gc=True)
             if meta_data.get("_use_colab_connector", False):
-                local_model = deserialize_model(local_model)
+                self._require_server_feature(
+                    "_use_colab_connector",
+                    self.use_colab_connector,
+                    client_id,
+                    context,
+                )
+                drive_handle = deserialize_model(local_model)
                 local_model = self.colab_connector.load_model(
-                    local_model["model_drive_path"]
+                    drive_handle["model_drive_path"]
                 )
             use_s3 = meta_data.get("_use_s3", False)
             if use_s3:
+                self._require_server_feature(
+                    "_use_s3", self.use_s3bucket, client_id, context
+                )
                 model_key = meta_data.get("model_key", None)
                 model_url = meta_data.get("model_url", None)
                 local_model = extract_model_from_s3(
@@ -344,6 +372,24 @@ class GRPCServerCommunicator(GRPCCommunicatorServicer):
                     "grpc",
                     deserialize_model(local_model),
                 )
+
+            # Validate the resulting state dict against the server's known
+            # model schema, regardless of which transport carried it. This is
+            # the structural defence: even payloads that survive deserialisation
+            # must match the federation's published parameter names and shapes.
+            if isinstance(local_model, bytes):
+                # Default tensor path: bytes go to ServerAgent._bytes_to_model
+                # which runs validate_state_dict internally. Nothing more to
+                # do here.
+                pass
+            else:
+                reference_model = getattr(self.server_agent, "model", None)
+                reference = (
+                    reference_model.state_dict()
+                    if reference_model is not None
+                    else None
+                )
+                validate_state_dict(local_model, reference=reference)
 
             # Streamed aggregation: chunk metadata is passed through to aggregator
             if self.use_model_chunking and "_chunk_idx" in meta_data:
@@ -643,6 +689,53 @@ class GRPCServerCommunicator(GRPCCommunicatorServicer):
             self.logger.info(
                 f"Server using proxystore for model transfer with store: {server_agent_config.server_configs.comm_configs.proxystore_configs.connector_type}."
             )
+
+    def _load_s3_flag(self, server_agent_config) -> None:
+        """Determine whether the operator has opted this server into S3-based
+        model transfer. The flag gates the ``_use_s3`` metadata field so that
+        an untrusted client cannot opt the server into that code path
+        unilaterally (which would otherwise let the client point the server
+        at an arbitrary URL and feed it an unsafe-deserialised reference
+        object).
+        """
+        self.use_s3bucket = False
+        try:
+            s3_configs = server_agent_config.server_configs.comm_configs.s3_configs
+        except (AttributeError, KeyError):
+            return
+        if s3_configs is None:
+            return
+        # Either an explicit enable flag or the presence of an s3_bucket
+        # value counts as opt-in.
+        enabled = bool(s3_configs.get("enable_s3", False)) or bool(
+            s3_configs.get("s3_bucket", None)
+        )
+        self.use_s3bucket = enabled
+
+    def _require_server_feature(
+        self, flag_name: str, server_enabled: bool, client_id: str, context
+    ) -> None:
+        """Refuse the request when the client set a feature flag in its
+        metadata but the server has not been opted into that feature.
+
+        Without this gate, the corresponding deserialisation branches run
+        ``torch.load(weights_only=False)`` on bytes the client controls, which
+        is direct RCE on the server. Raises a gRPC ``FAILED_PRECONDITION``
+        error so the client sees a clear refusal rather than a generic crash.
+        """
+        if server_enabled:
+            return
+        msg = (
+            f"Client {client_id!r} requested {flag_name}=True but this "
+            "server has not been configured for that transport. Refusing "
+            "the request: enabling the corresponding feature server-side "
+            "is required."
+        )
+        self.logger.warning(msg)
+        if context is not None:
+            context.set_code(grpc.StatusCode.FAILED_PRECONDITION)
+            context.set_details(msg)
+        raise ValueError(msg)
 
     def _load_google_drive(self, server_agent_config) -> None:
         self.use_colab_connector = False

--- a/src/appfl/comm/grpc/utils.py
+++ b/src/appfl/comm/grpc/utils.py
@@ -24,9 +24,22 @@ def serialize_model(model):
     return buffer.getvalue()
 
 
-def deserialize_model(model_bytes):
-    """Deserialize a model from a byte string."""
-    return torch.load(io.BytesIO(model_bytes))
+def deserialize_model(model_bytes, *, weights_only: bool = True):
+    """Deserialize a model from a byte string.
+
+    By default, this calls :func:`torch.load` with ``weights_only=True`` so
+    that arbitrary pickle payloads embedded in ``model_bytes`` cannot execute
+    Python during load. This is the correct setting for the common case where
+    the bytes hold a tensor state dict received from an untrusted peer.
+
+    Callers that legitimately need to round-trip non-tensor Python objects
+    (e.g. ``proxystore.proxy.Proxy`` references, Colab handles, or
+    ``CloudStorageObject`` references) must pass ``weights_only=False``
+    explicitly *and* ensure the operation is gated by a server-side opt-in to
+    the corresponding feature — otherwise an attacker can put a pickle gadget
+    in ``model_bytes`` and trigger code execution.
+    """
+    return torch.load(io.BytesIO(model_bytes), weights_only=weights_only)
 
 
 def load_credential_from_file(filepath):

--- a/src/appfl/comm/utils/state_dict_validation.py
+++ b/src/appfl/comm/utils/state_dict_validation.py
@@ -21,7 +21,7 @@ payload is at least a mapping of strings to tensors.
 
 from __future__ import annotations
 
-from typing import Mapping, Optional
+from typing import Mapping
 
 import torch
 
@@ -36,7 +36,7 @@ class InvalidStateDictPayload(ValueError):
 def validate_state_dict(
     payload: object,
     *,
-    reference: Optional[Mapping[str, torch.Tensor]] = None,
+    reference: Mapping[str, torch.Tensor] | None = None,
     allow_subset: bool = True,
 ) -> Mapping[str, torch.Tensor]:
     """Validate that ``payload`` is a state dict compatible with ``reference``.

--- a/src/appfl/comm/utils/state_dict_validation.py
+++ b/src/appfl/comm/utils/state_dict_validation.py
@@ -1,0 +1,108 @@
+"""Strict schema validation for incoming model state dicts.
+
+In APPFL's federated-learning protocol a client is supposed to return an
+updated version of the *server's* model — same architecture, same set of
+parameter names, same per-parameter shape and dtype, just different tensor
+values. A client is **not** supposed to send arbitrary Python objects, or a
+state dict for a different architecture, or extra keys.
+
+This module provides :func:`validate_state_dict`, which makes that contract
+explicit at the receiving end. It is a structural defence on top of
+``torch.load(weights_only=True)``: even a payload that survives the weights-only
+unpickler must still satisfy the federation's known schema, or it is rejected
+before anything else touches it.
+
+The reference schema is derived from ``server_agent.model.state_dict()`` and
+passed in by the caller; if no reference is supplied (e.g. the server was
+configured without a model architecture, which happens for some compression-only
+deployments), the validator falls back to a shape-agnostic check that the
+payload is at least a mapping of strings to tensors.
+"""
+
+from __future__ import annotations
+
+from typing import Mapping, Optional
+
+import torch
+
+
+class InvalidStateDictPayload(ValueError):
+    """Raised when an incoming model payload does not match the federation's
+    expected state-dict schema. Catching code should treat this as a protocol
+    error (the client sent something that cannot possibly be a legitimate
+    update), not as a transient failure."""
+
+
+def validate_state_dict(
+    payload: object,
+    *,
+    reference: Optional[Mapping[str, torch.Tensor]] = None,
+    allow_subset: bool = True,
+) -> Mapping[str, torch.Tensor]:
+    """Validate that ``payload`` is a state dict compatible with ``reference``.
+
+    :param payload: The object that was deserialised from the wire (or
+        extracted from proxystore / S3 / colab transport). Anything other
+        than a ``Mapping[str, torch.Tensor]`` is rejected.
+    :param reference: Optional mapping of expected parameter names to tensors
+        whose ``shape`` and ``dtype`` define the legal schema. When supplied,
+        every key in ``payload`` must be present in ``reference`` and every
+        tensor's shape and dtype must match.
+    :param allow_subset: When ``True`` (the default) the payload may carry
+        only a subset of the reference keys, which is the case for chunked
+        aggregation. Set to ``False`` to require the payload to cover the
+        full key set.
+    :return: ``payload`` (unchanged) when validation succeeds. Returning the
+        value lets callers chain ``model = validate_state_dict(model, ...)``.
+    :raises InvalidStateDictPayload: When the payload fails any check.
+    """
+    if not isinstance(payload, Mapping):
+        raise InvalidStateDictPayload(
+            f"expected a Mapping[str, torch.Tensor] state dict, got "
+            f"{type(payload).__name__}"
+        )
+
+    for key, value in payload.items():
+        if not isinstance(key, str):
+            raise InvalidStateDictPayload(f"state dict key {key!r} is not a string")
+        if not isinstance(value, torch.Tensor):
+            raise InvalidStateDictPayload(
+                f"state dict value for key {key!r} is not a torch.Tensor "
+                f"(got {type(value).__name__})"
+            )
+
+    if reference is None:
+        return payload
+
+    ref_keys = set(reference.keys())
+    payload_keys = set(payload.keys())
+
+    unknown = payload_keys - ref_keys
+    if unknown:
+        raise InvalidStateDictPayload(
+            f"state dict contains unknown keys not present in the server's "
+            f"model: {sorted(unknown)[:5]}" + ("..." if len(unknown) > 5 else "")
+        )
+
+    if not allow_subset:
+        missing = ref_keys - payload_keys
+        if missing:
+            raise InvalidStateDictPayload(
+                f"state dict is missing required keys: {sorted(missing)[:5]}"
+                + ("..." if len(missing) > 5 else "")
+            )
+
+    for key, value in payload.items():
+        ref_tensor = reference[key]
+        if tuple(value.shape) != tuple(ref_tensor.shape):
+            raise InvalidStateDictPayload(
+                f"state dict tensor {key!r} has shape {tuple(value.shape)}, "
+                f"expected {tuple(ref_tensor.shape)}"
+            )
+        if value.dtype != ref_tensor.dtype:
+            raise InvalidStateDictPayload(
+                f"state dict tensor {key!r} has dtype {value.dtype}, "
+                f"expected {ref_tensor.dtype}"
+            )
+
+    return payload

--- a/tests/test_grpc_torch_load_safety.py
+++ b/tests/test_grpc_torch_load_safety.py
@@ -1,0 +1,388 @@
+"""Tests for safe ``torch.load`` use on the gRPC path.
+
+Covers three layered changes:
+
+1. :func:`appfl.comm.grpc.utils.deserialize_model` and the two private
+   deserialisers (``ServerAgent._bytes_to_model``,
+   ``GRPCClientCommunicator._deserialize_model_optimized``) all pass
+   ``weights_only=True`` to ``torch.load``. A pickle gadget embedded in the
+   payload must raise rather than execute.
+
+2. ``GRPCServerCommunicator`` refuses ``_use_proxystore`` /
+   ``_use_colab_connector`` / ``_use_s3`` metadata flags from the client
+   unless the corresponding server-side feature is enabled, so a malicious
+   client cannot opt the server into the only branches that still need
+   ``weights_only=False``.
+
+3. ``validate_state_dict`` enforces the federation's actual schema (keys,
+   shapes, dtypes) on whatever was deserialised. Even payloads that survive
+   the weights-only unpickler must match the server's model, so a client
+   cannot inject arbitrary tensors / objects / extra parameters.
+"""
+
+from __future__ import annotations
+
+import io
+
+import grpc
+import pytest
+import torch
+
+import appfl.comm.grpc.utils as grpc_utils
+from appfl.comm.grpc.utils import deserialize_model, serialize_model
+
+
+# ---------------------------------------------------------------------------
+# (1) weights_only=True on the deserialisers.
+# ---------------------------------------------------------------------------
+
+
+_GADGET_MARKER = {"executed": False}
+
+
+def _fire_gadget():
+    """Module-level so pickle can address it. Sets a marker if it ever runs."""
+    _GADGET_MARKER["executed"] = True
+    return "gadget-return"
+
+
+class _PickleGadget:
+    """Object whose unpickling executes :func:`_fire_gadget`. Used as a
+    positive control: if ``torch.load`` runs Python at deserialise time, the
+    side effect on the marker dict happens."""
+
+    def __reduce__(self):
+        return (_fire_gadget, ())
+
+
+def _gadget_bytes() -> bytes:
+    """Produce torch-saved bytes that ``torch.load(weights_only=False)``
+    would execute and ``torch.load(weights_only=True)`` must refuse.
+
+    We wrap the gadget in a torch.save container so the bytes are a valid
+    torch checkpoint envelope — what an attacker would actually send. Bare
+    ``pickle.dumps`` lacks the magic number and would fail before the
+    weights_only check.
+    """
+    _GADGET_MARKER["executed"] = False
+    buf = io.BytesIO()
+    torch.save({"evil": _PickleGadget()}, buf)
+    return buf.getvalue()
+
+
+def test_deserialize_model_defaults_to_weights_only():
+    """Sanity-check the default kwarg — the whole PR rests on this default."""
+    import inspect
+
+    params = inspect.signature(grpc_utils.deserialize_model).parameters
+    assert params["weights_only"].default is True, (
+        "deserialize_model must default to weights_only=True; "
+        f"got {params['weights_only'].default!r}"
+    )
+
+
+def test_deserialize_model_rejects_pickle_gadget():
+    """A pickle gadget shipped as a fake 'model' must NOT execute."""
+    payload = _gadget_bytes()
+    with pytest.raises(Exception):
+        deserialize_model(payload)
+    assert _GADGET_MARKER["executed"] is False, (
+        "pickle gadget executed during deserialize_model — weights_only is "
+        "not being enforced"
+    )
+
+
+def test_deserialize_model_round_trips_state_dict():
+    """The happy path: a torch state dict round-trips through
+    serialize_model -> deserialize_model unchanged."""
+    state = {
+        "linear.weight": torch.randn(3, 4),
+        "linear.bias": torch.zeros(4),
+        "step": torch.tensor(7, dtype=torch.int64),
+    }
+    blob = serialize_model(state)
+    out = deserialize_model(blob)
+    assert set(out.keys()) == set(state.keys())
+    for k in state:
+        assert torch.equal(out[k], state[k])
+
+
+def test_deserialize_model_explicit_weights_only_false_runs_pickle():
+    """Smoke test of the escape hatch: passing weights_only=False explicitly
+    opts back into the unsafe codec. Guards against the kwarg being
+    silently dropped by a future refactor."""
+    payload = _gadget_bytes()
+    deserialize_model(payload, weights_only=False)
+    assert _GADGET_MARKER["executed"] is True
+
+
+def test_server_bytes_to_model_uses_weights_only(monkeypatch):
+    """ServerAgent._bytes_to_model must refuse a pickle gadget too."""
+    from appfl.agent.server import ServerAgent
+
+    # Build a minimal ServerAgent without going through the full config path:
+    # only _bytes_to_model is under test and it only depends on two flags.
+    agent = ServerAgent.__new__(ServerAgent)
+    agent.enable_compression = False
+    agent.optimize_memory = True
+
+    payload = _gadget_bytes()
+    with pytest.raises(Exception):
+        agent._bytes_to_model(payload)
+    assert _GADGET_MARKER["executed"] is False
+
+    # And again on the non-optimize_memory branch.
+    agent.optimize_memory = False
+    with pytest.raises(Exception):
+        agent._bytes_to_model(_gadget_bytes())
+    assert _GADGET_MARKER["executed"] is False
+
+
+def test_client_deserialize_uses_weights_only(monkeypatch):
+    """GRPCClientCommunicator._deserialize_model_optimized refuses a gadget.
+
+    The client communicator's __init__ opens a real gRPC channel, so we
+    construct the object without calling __init__ and exercise the bound
+    method directly.
+    """
+    from appfl.comm.grpc.grpc_client_communicator import GRPCClientCommunicator
+
+    client = GRPCClientCommunicator.__new__(GRPCClientCommunicator)
+    payload = _gadget_bytes()
+    with pytest.raises(Exception):
+        client._deserialize_model_optimized(payload)
+    assert _GADGET_MARKER["executed"] is False
+
+
+# ---------------------------------------------------------------------------
+# (2) Server-side feature gates on _use_proxystore / _use_colab_connector /
+#     _use_s3. Direct unit tests of the helper — full gRPC integration is
+#     covered by the existing test suite on the happy path.
+# ---------------------------------------------------------------------------
+
+
+def _bare_servicer():
+    from appfl.comm.grpc.grpc_server_communicator import GRPCServerCommunicator
+
+    s = GRPCServerCommunicator.__new__(GRPCServerCommunicator)
+
+    class _NullLogger:
+        def warning(self, *a, **kw):
+            pass
+
+        def info(self, *a, **kw):
+            pass
+
+    s.logger = _NullLogger()
+    return s
+
+
+class _FakeContext:
+    def __init__(self):
+        self.code = None
+        self.details = None
+
+    def set_code(self, code):
+        self.code = code
+
+    def set_details(self, details):
+        self.details = details
+
+
+def test_require_server_feature_allows_when_enabled():
+    s = _bare_servicer()
+    ctx = _FakeContext()
+    # Must not raise, must not touch the context.
+    s._require_server_feature("_use_proxystore", True, "client-1", ctx)
+    assert ctx.code is None
+    assert ctx.details is None
+
+
+def test_require_server_feature_refuses_when_disabled():
+    s = _bare_servicer()
+    ctx = _FakeContext()
+    with pytest.raises(ValueError, match="_use_proxystore"):
+        s._require_server_feature("_use_proxystore", False, "client-1", ctx)
+    assert ctx.code == grpc.StatusCode.FAILED_PRECONDITION
+    assert "client-1" in ctx.details
+    assert "_use_proxystore" in ctx.details
+
+
+@pytest.mark.parametrize("flag", ["_use_proxystore", "_use_colab_connector", "_use_s3"])
+def test_require_server_feature_message_names_flag(flag):
+    """The refusal must name the offending flag so the client can debug."""
+    s = _bare_servicer()
+    ctx = _FakeContext()
+    with pytest.raises(ValueError, match=flag):
+        s._require_server_feature(flag, False, "alice", ctx)
+    assert flag in ctx.details
+
+
+# ---------------------------------------------------------------------------
+# (3) validate_state_dict — structural schema enforcement.
+# ---------------------------------------------------------------------------
+
+
+from appfl.comm.utils.state_dict_validation import (  # noqa: E402
+    InvalidStateDictPayload,
+    validate_state_dict,
+)
+
+
+def _reference():
+    return {
+        "linear.weight": torch.zeros(3, 4),
+        "linear.bias": torch.zeros(4),
+    }
+
+
+def test_validate_accepts_matching_state_dict():
+    payload = {
+        "linear.weight": torch.randn(3, 4),
+        "linear.bias": torch.randn(4),
+    }
+    out = validate_state_dict(payload, reference=_reference())
+    assert out is payload
+
+
+def test_validate_accepts_subset_for_chunked_aggregation():
+    """Chunked aggregation sends partial state dicts; that must be allowed
+    by default (``allow_subset=True``)."""
+    payload = {"linear.bias": torch.randn(4)}
+    validate_state_dict(payload, reference=_reference())
+
+
+def test_validate_rejects_subset_when_full_required():
+    with pytest.raises(InvalidStateDictPayload, match="missing required keys"):
+        validate_state_dict(
+            {"linear.bias": torch.randn(4)},
+            reference=_reference(),
+            allow_subset=False,
+        )
+
+
+def test_validate_rejects_non_mapping():
+    with pytest.raises(InvalidStateDictPayload, match="Mapping"):
+        validate_state_dict([torch.zeros(3)], reference=_reference())
+
+
+def test_validate_rejects_non_string_key():
+    payload = {0: torch.zeros(4)}
+    with pytest.raises(InvalidStateDictPayload, match="not a string"):
+        validate_state_dict(payload, reference=_reference())
+
+
+def test_validate_rejects_non_tensor_value():
+    payload = {"linear.weight": [[1, 2, 3, 4]] * 3}
+    with pytest.raises(InvalidStateDictPayload, match="not a torch.Tensor"):
+        validate_state_dict(payload, reference=_reference())
+
+
+def test_validate_rejects_unknown_key():
+    payload = {
+        "linear.weight": torch.randn(3, 4),
+        "extra.injected": torch.randn(1),
+    }
+    with pytest.raises(InvalidStateDictPayload, match="unknown keys"):
+        validate_state_dict(payload, reference=_reference())
+
+
+def test_validate_rejects_wrong_shape():
+    payload = {"linear.weight": torch.randn(99, 99)}
+    with pytest.raises(InvalidStateDictPayload, match="shape"):
+        validate_state_dict(payload, reference=_reference())
+
+
+def test_validate_rejects_wrong_dtype():
+    payload = {"linear.weight": torch.randn(3, 4).to(torch.float64)}
+    with pytest.raises(InvalidStateDictPayload, match="dtype"):
+        validate_state_dict(payload, reference=_reference())
+
+
+def test_validate_without_reference_is_shape_agnostic():
+    """When the server was started without a model architecture, the
+    validator falls back to type checks only."""
+    validate_state_dict({"any.key": torch.randn(7)})
+    with pytest.raises(InvalidStateDictPayload):
+        validate_state_dict({"any.key": "not a tensor"})
+
+
+# Integration: _bytes_to_model now runs the validator and rejects an
+# extra-key payload even if weights_only=True accepts it.
+
+
+def test_bytes_to_model_rejects_extra_keys(tmp_path):
+    """A torch-saved state dict with an extra parameter must be rejected
+    against the server's reference, not silently aggregated."""
+    from appfl.agent.server import ServerAgent
+
+    agent = ServerAgent.__new__(ServerAgent)
+    agent.enable_compression = False
+    agent.optimize_memory = True
+
+    # Plant a reference model that only has linear.weight.
+    class _RefModel:
+        def state_dict(self):
+            return {"linear.weight": torch.zeros(3, 4)}
+
+    agent.model = _RefModel()
+
+    payload = {
+        "linear.weight": torch.randn(3, 4),
+        "evil.backdoor": torch.randn(99),
+    }
+    buf = io.BytesIO()
+    torch.save(payload, buf)
+
+    with pytest.raises(InvalidStateDictPayload):
+        agent._bytes_to_model(buf.getvalue())
+
+
+def test_bytes_to_model_rejects_wrong_shape_tensor():
+    from appfl.agent.server import ServerAgent
+
+    agent = ServerAgent.__new__(ServerAgent)
+    agent.enable_compression = False
+    agent.optimize_memory = True
+
+    class _RefModel:
+        def state_dict(self):
+            return {"linear.weight": torch.zeros(3, 4)}
+
+    agent.model = _RefModel()
+
+    payload = {"linear.weight": torch.randn(99, 99)}
+    buf = io.BytesIO()
+    torch.save(payload, buf)
+
+    with pytest.raises(InvalidStateDictPayload):
+        agent._bytes_to_model(buf.getvalue())
+
+
+def test_bytes_to_model_accepts_matching_payload():
+    """Round-trip sanity: the happy path still works after adding the
+    validator."""
+    from appfl.agent.server import ServerAgent
+
+    agent = ServerAgent.__new__(ServerAgent)
+    agent.enable_compression = False
+    agent.optimize_memory = True
+
+    class _RefModel:
+        def state_dict(self):
+            return {
+                "linear.weight": torch.zeros(3, 4),
+                "linear.bias": torch.zeros(4),
+            }
+
+    agent.model = _RefModel()
+
+    payload = {
+        "linear.weight": torch.randn(3, 4),
+        "linear.bias": torch.randn(4),
+    }
+    buf = io.BytesIO()
+    torch.save(payload, buf)
+
+    out = agent._bytes_to_model(buf.getvalue())
+    assert set(out.keys()) == {"linear.weight", "linear.bias"}


### PR DESCRIPTION
## Summary

In APPFL a client is supposed to return an updated version of the *server's* model — same architecture, same parameter names, same per-tensor shape and dtype, just different values. The server already has the reference state dict on hand (`server_agent.model.state_dict()`). Before this change the gRPC server happily accepted anything that survived `torch.load`, which (a) defaulted to `weights_only=False`, opening the standard pickle-gadget code-execution path, and (b) never compared the received parameters to the schema it actually expects, so a client could ship a state dict for a different architecture or insert extra keys without protest. This PR adds three layered defences so that a client must either send a payload that matches the federation's schema or have its request refused before any aggregator sees it. First, every `torch.load` call on the gRPC path now passes `weights_only=True`, so the unpickler refuses anything outside torch's tensor-pickle subset; this alone closes the dominant RCE primitive. Second, the four code paths that produce a state dict — the default tensor path (`ServerAgent._bytes_to_model`) and the three alternative-transport paths (proxystore, colab, S3) — all run their result through a new `validate_state_dict(payload, *, reference=...)` helper that rejects anything that is not a `Mapping[str, torch.Tensor]` and, when the reference is available, rejects unknown keys, wrong shapes, and wrong dtypes. Third, the three alternative-transport branches are gated on a server-side opt-in flag (`use_proxystore`, `use_colab_connector`, `use_s3bucket`) so an unauthorised client cannot opt the server into the only branch that still legitimately needs `weights_only=False` (proxystore, where the `Proxy` class wraps a user-defined factory). The S3 and colab branches no longer use `weights_only=False` at all — their reference objects are plain dicts and round-trip safely through the weights-only unpickler. Net effect on attack surface: a pickle gadget in the model payload is rejected by the unpickler; a payload that survives the unpickler but doesn't match the federation's published model is rejected by the validator; and the only place that still trusts pickle (the proxystore Proxy round-trip) requires the operator to have explicitly enabled proxystore server-side, after which the validator still runs on the extracted state dict before it reaches the aggregator.

## What changed

`src/appfl/comm/utils/state_dict_validation.py` — new module. Defines `InvalidStateDictPayload` (a `ValueError` subclass) and `validate_state_dict(payload, *, reference=None, allow_subset=True)`. Without a reference it enforces `Mapping[str, torch.Tensor]`. With a reference it additionally enforces that every key is in the reference, every tensor's `shape` matches `tuple(reference[k].shape)`, and every dtype matches. `allow_subset=True` (the default) permits partial state dicts as used by the chunked-aggregation code path; the `allow_subset=False` mode is available for callers that want exact equality.

`src/appfl/comm/grpc/utils.py` — `deserialize_model(model_bytes, *, weights_only=True)` now takes a keyword-only flag, defaults safe, and documents the constraint that callers needing `weights_only=False` must gate on a server-side feature.

`src/appfl/comm/grpc/grpc_client_communicator.py` — `_deserialize_model_optimized` passes `weights_only=True`. The threat model treats the server as trusted, so the client side is defence-in-depth; the global model is always a tensor state dict on the legitimate path so this is free.

`src/appfl/agent/server.py` — `_bytes_to_model` now (a) passes `weights_only=True` to `torch.load`, and (b) runs `validate_state_dict` with `self.model.state_dict()` as the reference (or no reference if `self.model is None`, which is the compression-only case). The compression branch is unchanged — `compressor.decompress_model` already operates on the typed model and is a separate finding.

`src/appfl/comm/grpc/grpc_server_communicator.py` — new `_load_s3_flag` reads `server_configs.comm_configs.s3_configs` and sets `self.use_s3bucket = True` if `enable_s3` is set or if an `s3_bucket` value is present. New `_require_server_feature(flag_name, server_enabled, client_id, context)` helper that raises `ValueError` with `grpc.StatusCode.FAILED_PRECONDITION` when the server hasn't been opted into a requested transport. Called at the top of each of the three alternative-transport branches in `UpdateGlobalModel` and in `GetGlobalModel`'s `_use_s3` branch. The colab and S3 deserialisations dropped their `weights_only=False` (their reference objects are plain dicts). The proxystore branch keeps `weights_only=False` for the `Proxy` round-trip — the Proxy carries a user-defined factory and cannot survive the weights-only unpickler — but it now runs after the server-side gate AND its extracted state dict goes through the validator. The `UpdateGlobalModel` handler ends with a unified validator call so that whichever transport carried the state dict, the same schema check applies before the bytes reach the aggregator.

## Tests

`tests/test_grpc_torch_load_safety.py` — 24 tests, plain pytest, ~3 s. Three sections: (1) `weights_only=True` on the deserialisers, including a pickle-gadget positive control wrapped in `torch.save` (bare `pickle.dumps` would fail before the weights-only check because it lacks the magic number); (2) feature-gate refusal across all four flags; (3) `validate_state_dict` behaviour — accepts matching, accepts subset for chunked aggregation, rejects subset when `allow_subset=False`, rejects non-mapping, non-string key, non-tensor value, unknown key, wrong shape, wrong dtype, and falls back to type-only checks when no reference is supplied. Two integration tests demonstrate the end-to-end behaviour: a torch-saved state dict with an extra parameter is rejected by `_bytes_to_model`, and a wrong-shape tensor is rejected the same way. A matching payload still round-trips cleanly through the new validator.

Existing suite: non-MPI tests `87 passed in 3 s`, MPI tests `1 passed, 7 skipped in 45 s`. `ruff check` and `ruff format --check` clean on the six touched source files.

## Breaking changes

Three changes for operators currently relying on the unguarded behaviour. First, deployments that use proxystore for model transport must have `enable_proxystore: true` set in `server_configs.comm_configs.proxystore_configs`; this was already required for the server to construct its own outgoing proxy, and this PR makes it also required to accept incoming ones from clients. Second, same for `colab_connector_configs.enable: true`. Third, deployments that use S3-based model transfer must now set either `enable_s3: true` or an `s3_bucket: ...` value under `server_configs.comm_configs.s3_configs`; previously the server trusted any client to opt it into S3 transfer per-request, and that is now an operator-side decision. Clients whose configs already set `s3_configs` on the server side are unaffected. Anyone constructing a non-standard state dict — e.g. with extra debugging keys, or a tensor whose dtype differs from the server's reference — must align with the server's schema; the error message names the offending key/shape/dtype. Callers of `appfl.comm.grpc.deserialize_model(bytes)` who legitimately need to round-trip non-tensor Python objects must now pass `weights_only=False` explicitly and accept the risk.

## Residual gap

When the operator has enabled proxystore server-side, the `Proxy` round-trip itself still happens via `torch.load(weights_only=False)`. An authenticated client could therefore embed a pickle gadget in the `Proxy` envelope and obtain code execution on the server. The `validate_state_dict` defence kicks in *after* `extract(proxy)`, so it cannot help with the Proxy itself. The proper fix is to stop transporting the Proxy via `torch.save`/`torch.load` and instead send a proxystore key in `meta_data`, letting the server reconstruct the Proxy from its own connector — that change touches the client side of the proxystore code path and is filed as a follow-up. For deployments that use proxystore today the trust model becomes "authenticated clients are trusted not to embed gadgets in their Proxy envelopes," which is defensible only when authentication is real (so the `NaiveAuthenticator` default-token finding is a precondition for trusting this).

## Out of scope

The MPI backend's `torch.load` sites are intentionally not touched: APPFL's MPI mode is single-user (one `mpirun` allocation, one Unix UID across all ranks), so the threat does not apply there. The compressor path (`compressor.decompress_model`) calls `pickle.loads` internally; that is a separate finding and would require coordinated changes in the SZ2/SZ3/ZFP wrappers. The TES and `misc/utils.py` `torch.load` sites read local files chosen by the operator and are out of scope for this PR (different trust boundary).

## Test plan (for reviewer)

- [ ] `.conda/bin/python -m pytest tests/test_grpc_torch_load_safety.py -q` (new tests).
- [ ] `.conda/bin/python -m pytest tests/ --ignore=tests/test_mnist.py -q` (existing non-MPI suite, must stay green).
- [ ] `mpirun -n 2 .conda/bin/python -m pytest --with-mpi tests/test_mnist.py -q` (MPI suite, unchanged).
- [ ] Manually verify that running a normal gRPC FL example (e.g. `examples/grpc/run_server.py` + two clients on the MNIST configs) still completes a round end-to-end.
- [ ] If you have a proxystore / colab / S3-enabled deployment, verify it still works when the corresponding `enable_*` server-side flag is set, and that a client trying to opt the server into one of those transports without the flag now gets a clear `FAILED_PRECONDITION` error instead of silently working.
- [ ] If you can, construct a deliberately mismatched state dict (extra key, wrong shape) and confirm the server refuses it with a clear `InvalidStateDictPayload` message naming the offending parameter.