### PR TITLE
Fix divide-by-zero (NaN) crash in dirichlet_noniid_partition (issue # 426)

### DIFF
--- a/src/appfl/misc/data.py
+++ b/src/appfl/misc/data.py
@@ -446,10 +446,9 @@ def dirichlet_noniid_partition(
     normalized_portions = np.zeros(individuals.shape)
     for i in range(num_clients):
         for j in range(len(classes_samples)):
+            denom = np.dot(weights, individuals.transpose()[j])
             normalized_portions[i][j] = (
-                weights[i]
-                * individuals[i][j]
-                / np.dot(weights, individuals.transpose()[j])
+                weights[i] * individuals[i][j] / denom if denom > 0 else 0.0
             )
 
     sample_matrix = np.multiply(
@@ -704,8 +703,9 @@ def dirichlet_noniid_partition_df(
         for j in range(len(classes_samples)):
             # This line effectively normalizes so that sum over i for individuals[i][j]
             # matches the fraction of class j in the entire dataset
+            denom = np.dot(weights, individuals[:, j])
             normalized_portions[i][j] = (
-                weights[i] * individuals[i][j] / np.dot(weights, individuals[:, j])
+                weights[i] * individuals[i][j] / denom if denom > 0 else 0.0
             )
 
     sample_matrix = np.multiply(

--- a/tests/test_dirichlet_partition_nan.py
+++ b/tests/test_dirichlet_partition_nan.py
@@ -1,0 +1,65 @@
+"""Regression test for the divide-by-zero NaN crash in Dirichlet partitioning.
+
+Before the fix, ``dirichlet_noniid_partition`` (and its DataFrame variant) divided
+the per-class normalization by ``np.dot(weights, individuals[:, j])`` with no
+guard. For strongly non-IID settings (many classes + many clients + small
+Dirichlet ``alpha2``) a whole class column of ``individuals`` can be exactly zero,
+making the denominator 0 -> 0/0 = NaN -> ``int(sample_matrix[...])`` raised
+``ValueError: cannot convert float NaN to integer``.
+
+The parameters below (100 classes, 128 clients, alpha2=0.01, seed=17) were found
+to produce an all-zero class column, i.e. they crash on the unfixed code and pass
+with the guard. This test therefore fails if the guard is ever removed.
+"""
+
+import torch
+from torch.utils.data import Dataset
+
+from appfl.misc.data import dirichlet_noniid_partition
+
+
+class _TinyLabeled(Dataset):
+    """Minimal (input, label) dataset with a controllable number of classes."""
+
+    def __init__(self, num_classes: int, per_class: int):
+        labels = []
+        for c in range(num_classes):
+            labels.extend([c] * per_class)
+        self._x = torch.zeros((len(labels), 1, 2, 2), dtype=torch.float32)
+        self._y = torch.tensor(labels, dtype=torch.long)
+
+    def __len__(self):
+        return len(self._y)
+
+    def __getitem__(self, idx):
+        return self._x[idx], int(self._y[idx])
+
+
+def test_dirichlet_partition_zero_class_column_no_nan_crash():
+    """A settings combo that yields an all-zero class column must not crash.
+
+    On the unfixed code this raises
+    ``ValueError: cannot convert float NaN to integer``.
+    """
+    num_clients = 128
+    dataset = _TinyLabeled(num_classes=100, per_class=10)
+
+    client_datasets = dirichlet_noniid_partition(
+        dataset,
+        num_clients,
+        visualization=False,
+        alpha1=num_clients,
+        alpha2=0.01,
+        seed=17,
+    )
+
+    # Must return one dataset per client with a valid integer sample count, and
+    # every sample must be accounted for exactly once.
+    assert len(client_datasets) == num_clients
+    total = 0
+    for ds in client_datasets:
+        n = len(ds)
+        assert isinstance(n, int)
+        assert n >= 0
+        total += n
+    assert total == len(dataset)


### PR DESCRIPTION
# Description
`dirichlet_noniid_partition` (and its DataFrame twin `dirichlet_noniid_partition_df`)
in `src/appfl/misc/data.py` could crash with
`ValueError: cannot convert float NaN to integer` at partition time for standard
non-IID settings (many classes + many clients + small Dirichlet `alpha2`).

Root cause: the per-class normalization divides by
`np.dot(weights, individuals[:, j])` with no guard. With a small `alpha2` spread
over many classes, a whole class column of `individuals` can be all-zero (or
underflow to 0), making the denominator exactly 0 → `0/0 = NaN` → the later
`int(sample_matrix[...])` raises.

This PR guards the denominator in both functions: when it is 0 (i.e. no client
sampled that class), the normalized portion is set to `0.0`, which is the correct
mathematical limit. When the denominator is positive, behavior is unchanged.
The existing last-client remainder correction keeps per-class totals conserved.


### Fixes
- Fixes #426 

### Type of Change
<!--- Check which off the following types describe this PR: Enter X into brackets to check --->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (internal implementation changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (no changes to the code)
- [ ] CI change (changes to CI workflows, packages, templates, etc.)
- [ ] Version changes (changes to the package or dependency versions)

## Testing

Added a regression test that forces an all-zero class column (the exact
condition that produced the NaN) and asserts the partition completes without
raising and returns integer per-client class counts. Confirmed the test fails on
`main` (raises `ValueError: cannot convert float NaN to integer`) and passes with
this fix. Existing partition tests still pass.

## Other Pull Request Checklist

Please confirm the PR meets the following requirements.
- [ ] Code changes pass `pre-commit` (e.g., ruff, mypy, etc.) via `pre-commit run --all-files`.
- [X] Tests have been added to show the fix is effective or that the new feature works.
- [X] New and existing unit tests pass locally with the changes.
- [X] Docs have been updated and reviewed if relevant.
