### PR TITLE
Add Keycloak authenticator for FL client/server auth

### DIFF
--- a/examples/resources/configs/mnist/client_1_keycloak_auth.yaml
+++ b/examples/resources/configs/mnist/client_1_keycloak_auth.yaml
@@ -1,0 +1,35 @@
+client_id: "Client1"
+
+train_configs:
+  # Device
+  device: "cpu"
+  # Logging and outputs
+  logging_output_dirname: "./output"
+  logging_output_filename: "result"
+
+# Local dataset
+data_configs:
+  dataset_path: "./resources/dataset/mnist_dataset.py"
+  dataset_name: "get_mnist"
+  dataset_kwargs:
+    num_clients: 2
+    client_id: 0
+    partition_strategy: "class_noniid"
+    visualization: True
+    output_dirname: "./output"
+    output_filename: "visualization.pdf"
+
+comm_configs:
+  grpc_configs:
+    server_uri: localhost:50051
+    max_message_size: 1048576
+    use_ssl: True
+    root_certificate: "/your-home/.appfl/ssl/ca.crt"
+    use_authenticator: True
+    authenticator: "KeycloakAuthenticator"
+    authenticator_args:
+      is_fl_server: False
+      server_url: "http://localhost:8080"
+      realm: "appfl"
+      client_id: "fl-client-1"
+      client_secret: "<client-secret-from-keycloak>" # never commit a real secret here

--- a/examples/resources/configs/mnist/client_2_keycloak_auth.yaml
+++ b/examples/resources/configs/mnist/client_2_keycloak_auth.yaml
@@ -1,0 +1,35 @@
+client_id: "Client2"
+
+train_configs:
+  # Device
+  device: "cpu"
+  # Logging and outputs
+  logging_output_dirname: "./output"
+  logging_output_filename: "result"
+
+# Local dataset
+data_configs:
+  dataset_path: "./resources/dataset/mnist_dataset.py"
+  dataset_name: "get_mnist"
+  dataset_kwargs:
+    num_clients: 2
+    client_id: 1
+    partition_strategy: "class_noniid"
+    visualization: True
+    output_dirname: "./output"
+    output_filename: "visualization.pdf"
+
+comm_configs:
+  grpc_configs:
+    server_uri: localhost:50051
+    max_message_size: 1048576
+    use_ssl: True
+    root_certificate: "/your-home/.appfl/ssl/ca.crt"
+    use_authenticator: True
+    authenticator: "KeycloakAuthenticator"
+    authenticator_args:
+      is_fl_server: False
+      server_url: "http://localhost:8080"
+      realm: "appfl"
+      client_id: "fl-client-2"
+      client_secret: "<client-secret-from-keycloak>" # never commit a real secret here

--- a/examples/resources/configs/mnist/server_fedavg_keycloak_auth.yaml
+++ b/examples/resources/configs/mnist/server_fedavg_keycloak_auth.yaml
@@ -1,0 +1,74 @@
+client_configs:
+  train_configs:
+    # Local trainer
+    trainer: "VanillaTrainer"
+    mode: "step"
+    num_local_steps: 100
+    optim: "Adam"
+    optim_args:
+      lr: 0.001
+    # Loss function
+    loss_fn_path: "./resources/loss/celoss.py"
+    loss_fn_name: "CELoss"
+    # Client validation
+    do_validation: True
+    do_pre_validation: True
+    metric_path: "./resources/metric/acc.py"
+    metric_name: "accuracy"
+    # Differential privacy
+    use_dp: False
+    epsilon: 1
+    # Mini-batch gradient clipping
+    clip_grad: False
+    clip_value: 1
+    clip_norm: 1
+    # Data loader
+    train_batch_size: 64
+    val_batch_size: 64
+    train_data_shuffle: True
+    val_data_shuffle: False
+
+  model_configs:
+    model_path: "./resources/model/cnn.py"
+    model_name: "CNN"
+    model_kwargs:
+      num_channel: 1
+      num_classes: 10
+      num_pixel: 28
+
+  comm_configs:
+    compressor_configs:
+      enable_compression: False
+      # Used if enable_compression is True
+      lossy_compressor:  "SZ2Compressor"
+      lossless_compressor: "blosc"
+      error_bounding_mode: "REL"
+      error_bound: 1e-3
+      param_cutoff: 1024
+
+server_configs:
+  num_clients: 2
+  scheduler: "SyncScheduler"
+  scheduler_kwargs:
+    same_init_model: True
+  aggregator: "FedAvgAggregator"
+  aggregator_kwargs:
+    client_weights_mode: "equal"
+  device: "cpu"
+  num_global_epochs: 10
+  logging_output_dirname: "./output"
+  logging_output_filename: "result"
+  comm_configs:
+    grpc_configs:
+      server_uri: 0.0.0.0:50051 # bind on all interfaces; clients connect via the server's reachable address
+      max_message_size: 1048576
+      use_ssl: True
+      server_certificate_key: "/your-home/.appfl/ssl/server.key"
+      server_certificate: "/your-home/.appfl/ssl/server.crt"
+      ca_certificate: "/your-home/.appfl/ssl/ca.crt"
+      use_authenticator: True
+      authenticator: "KeycloakAuthenticator"
+      authenticator_args:
+        is_fl_server: True
+        server_url: "http://localhost:8080"
+        realm: "appfl"

--- a/setup.py
+++ b/setup.py
@@ -74,6 +74,11 @@ setuptools.setup(
         globus_sdk_version,
         globus_compute_sdk_version,
         globus_compute_endpoint_version,
+        # >=2.6.0: older PyJWT crashes on Keycloak's JWKS response, which
+        # includes a non-signing RSA-OAEP encryption key alongside the RS256
+        # signing key.
+        "PyJWT[crypto]>=2.6.0",
+        "requests",
         "boto3",
         "botocore",
         "lz4",

--- a/src/appfl/login_manager/ReadME.md
+++ b/src/appfl/login_manager/ReadME.md
@@ -20,9 +20,10 @@ class BaseAuthenticator:
 ```
 
 ## Naive Authenticator
-Currently, we provide the two authenticators,
+Currently, we provide the following authenticators,
 - [`NaiveAuthenticator`](naive)
 - [`GlobusAuthenticator`](globus)
+- [`KeycloakAuthenticator`](keycloak)
 
 `NaiveAuthenticator` is a shared-secret scheme: the same `auth_token` must be configured on the server and on every client, and the server admits any peer that presents it. It is intended for demos and trusted-network testing only — production deployments should use `GlobusAuthenticator` (or another identity-bound mechanism).
 
@@ -159,3 +160,56 @@ For the logged in FL server, `valiate_auth_token()` function takes three steps t
 - Use the retrieved Globus Group Service access token to get all the client IDs for all clients in the specified Globus group
 - Take the Globus Identity access token provided by clients to get the client ID for that client
 - Check if the client ID belongs to the specified Globus group
+
+## Keycloak Authenticator
+`KeycloakAuthenticator` uses [Keycloak](https://www.keycloak.org/) as the identity provider. Each FL client is its own Keycloak confidential client (`client_id`/`client_secret`) and authenticates headlessly via the OAuth2 **client credentials grant** — no browser, so it works on compute nodes. The server verifies each token's signature against Keycloak's JWKS and requires an `fl_client` role.
+
+### Set up Keycloak
+- Create a realm (e.g. `appfl`) and an `fl_client` realm role (Realm roles → Create role).
+- For each FL client, create a Keycloak client with **Client authentication: On** and **Service accounts roles** enabled, then assign it `fl_client` (client → *Service accounts roles* tab → *Assign role*).
+- Get that client's secret from its *Credentials* tab.
+
+### Constructor
+```python
+KeycloakAuthenticator(
+    is_fl_server: bool = False,
+    server_url: str,                       # e.g. "https://keycloak.example.org"
+    realm: str,
+    client_id: Optional[str] = None,       # required for clients
+    client_secret: Optional[str] = None,   # required for clients
+    role: str = "fl_client",
+    role_client_id: Optional[str] = None,  # set if `role` is a client role, not a realm role
+    leeway: int = 10,                      # clock-skew tolerance (seconds) for token expiry
+)
+```
+
+### Config
+`use_ssl: True` is required whenever `use_authenticator: True`. Full examples: [server](../../../examples/resources/configs/mnist/server_fedavg_keycloak_auth.yaml), [client 1](../../../examples/resources/configs/mnist/client_1_keycloak_auth.yaml), [client 2](../../../examples/resources/configs/mnist/client_2_keycloak_auth.yaml).
+
+```yaml
+# server: server_configs.comm_configs.grpc_configs
+use_authenticator: True
+authenticator: "KeycloakAuthenticator"
+authenticator_args:
+  is_fl_server: True
+  server_url: "http://localhost:8080"
+  realm: "appfl"
+```
+```yaml
+# client: comm_configs.grpc_configs
+use_authenticator: True
+authenticator: "KeycloakAuthenticator"
+authenticator_args:
+  is_fl_server: False
+  server_url: "http://localhost:8080"
+  realm: "appfl"
+  client_id: "fl-client-1"
+  client_secret: "<client-secret-from-keycloak>"
+```
+
+### Example deployment
+Tested end-to-end with Keycloak on an AWS EC2 instance (`http://44.200.247.230:8080`, realm `appfl`), FL server on the same instance, FL clients connecting from a separate machine. For multi-device federations, host Keycloak somewhere every client can reach — not `localhost` — and put it behind HTTPS with brute-force protection enabled; the instance above currently runs with `sslRequired: none` for testing convenience only.
+
+### Auth Flow for Keycloak Authenticator
+- `get_auth_token()` (FL client): requests an access token from Keycloak's token endpoint (`/realms/{realm}/protocol/openid-connect/token`) using the client credentials grant, and returns `{"access_token": <jwt>}`.
+- `validate_auth_token()` (FL server): fetches Keycloak's public signing keys from its JWKS endpoint (`/realms/{realm}/protocol/openid-connect/certs`, cached after the first call), verifies the access token's signature, issuer, and expiry, then checks that the token's claims include the required `fl_client` role. Tokens that fail signature verification, are expired, or lack the role are rejected.

--- a/src/appfl/login_manager/__init__.py
+++ b/src/appfl/login_manager/__init__.py
@@ -1,10 +1,12 @@
 from .authenticator import BaseAuthenticator
 from .naive import NaiveAuthenticator
 from .globus import GlobusLoginManager, GlobusAuthenticator
+from .keycloak import KeycloakAuthenticator
 
 __all__ = [
     "BaseAuthenticator",
     "NaiveAuthenticator",
     "GlobusLoginManager",
     "GlobusAuthenticator",
+    "KeycloakAuthenticator",
 ]

--- a/src/appfl/login_manager/keycloak/__init__.py
+++ b/src/appfl/login_manager/keycloak/__init__.py
@@ -1,0 +1,3 @@
+from .keycloak_authenticator import KeycloakAuthenticator
+
+__all__ = ["KeycloakAuthenticator"]

--- a/src/appfl/login_manager/keycloak/keycloak_authenticator.py
+++ b/src/appfl/login_manager/keycloak/keycloak_authenticator.py
@@ -1,0 +1,116 @@
+from typing import Dict, Optional
+import requests
+import jwt
+from appfl.login_manager import BaseAuthenticator
+
+
+class KeycloakAuthenticator(BaseAuthenticator):
+    """
+    Authenticator for FL server and client using Keycloak (OIDC) with the
+    client credentials grant. Each FL client is registered in Keycloak as
+    its own confidential client (`client_id` + `client_secret`) and must be
+    assigned the `fl_client` role to be authorized to join the federation.
+
+    :param is_fl_server: Whether the authenticator is for the FL server or client.
+    :param server_url: Base URL of the Keycloak server, e.g. "https://keycloak.example.org".
+    :param realm: Keycloak realm name.
+    :param client_id: FL client's Keycloak client ID. Required for FL client.
+    :param client_secret: FL client's Keycloak client secret. Required for FL client.
+    :param role: Name of the role a client's token must carry to be authorized.
+    :param role_client_id: If `role` is a client role rather than a realm role,
+        the client ID under whose `resource_access` claim it should be looked up.
+        Leave `None` to check `role` as a realm role.
+    :param leeway: Clock-skew leeway (seconds) allowed when validating token expiry.
+    """
+
+    def __init__(
+        self,
+        *,
+        is_fl_server: bool = False,
+        server_url: str,
+        realm: str,
+        client_id: Optional[str] = None,
+        client_secret: Optional[str] = None,
+        role: str = "fl_client",
+        role_client_id: Optional[str] = None,
+        leeway: int = 10,
+    ) -> None:
+        self.is_fl_server = is_fl_server
+        self.realm = realm
+        self.role = role
+        self.role_client_id = role_client_id
+        self.leeway = leeway
+
+        issuer = f"{server_url.rstrip('/')}/realms/{realm}"
+        self.issuer = issuer
+        self.token_endpoint = f"{issuer}/protocol/openid-connect/token"
+
+        if self.is_fl_server:
+            # PyJWKClient caches the fetched key set, so signature verification
+            # does not hit Keycloak on every `validate_auth_token()` call.
+            self._jwk_client = jwt.PyJWKClient(
+                f"{issuer}/protocol/openid-connect/certs"
+            )
+        else:
+            assert client_id is not None and client_secret is not None, (
+                "FL client must provide `client_id` and `client_secret` to "
+                "authenticate with Keycloak."
+            )
+            self.client_id = client_id
+            self.client_secret = client_secret
+
+    def get_auth_token(self) -> Dict[str, str]:
+        """
+        Invoked by the FL client to obtain an access token from Keycloak via
+        the client credentials grant.
+        """
+        assert not self.is_fl_server, "Server does not need to obtain auth tokens"
+        response = requests.post(
+            self.token_endpoint,
+            data={
+                "grant_type": "client_credentials",
+                "client_id": self.client_id,
+                "client_secret": self.client_secret,
+            },
+            timeout=10,
+        )
+        response.raise_for_status()
+        return {"access_token": response.json()["access_token"]}
+
+    def validate_auth_token(self, token: Dict) -> bool:
+        """
+        Invoked by the FL server to validate a client's access token: verifies
+        the JWT's signature, issuer, and expiry against Keycloak's JWKS, then
+        checks that the token carries the required role.
+        """
+        assert self.is_fl_server, "Client does not need to validate auth tokens"
+        access_token = token.get("access_token")
+        if not isinstance(access_token, str) or not access_token:
+            return False
+        try:
+            signing_key = self._jwk_client.get_signing_key_from_jwt(access_token)
+            claims = jwt.decode(
+                access_token,
+                signing_key.key,
+                algorithms=["RS256"],
+                issuer=self.issuer,
+                leeway=self.leeway,
+                # Keycloak's default `aud` claim is not client-specific (it is
+                # typically "account"), so authorization here relies on the
+                # role check below rather than audience matching.
+                options={"verify_aud": False},
+            )
+        except jwt.PyJWTError:
+            return False
+        return self._has_role(claims)
+
+    def _has_role(self, claims: Dict) -> bool:
+        if self.role_client_id is not None:
+            roles = (
+                claims.get("resource_access", {})
+                .get(self.role_client_id, {})
+                .get("roles", [])
+            )
+        else:
+            roles = claims.get("realm_access", {}).get("roles", [])
+        return self.role in roles


### PR DESCRIPTION
# Description

Adds `KeycloakAuthenticator`, a new `BaseAuthenticator` implementation for FL client/server auth via Keycloak. Each FL client authenticates as its own confidential Keycloak client using the OAuth2 client-credentials grant (no browser, works headlessly on compute nodes). The server verifies each token's signature against Keycloak's JWKS and requires an `fl_client` role, same pattern as `GlobusAuthenticator` but without the interactive login step.

### Fixes

N/A — not tied to an existing issue.

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (internal implementation changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (no changes to the code)
- [ ] CI change (changes to CI workflows, packages, templates, etc.)
- [ ] Version changes (changes to the package or dependency versions)

## Testing

Tested end-to-end against a real Keycloak instance (local, then AWS-hosted) rather than mocks:
- Valid client + role → token issued, verified, RPC accepted.
- Wrong client secret → rejected at Keycloak, before reaching the FL server.
- Valid token but missing `fl_client` role → rejected by the server's role check.
- Full 2-client `FedAvg` MNIST run over SSL-enabled gRPC completed successfully with `KeycloakAuthenticator` on both sides.

No automated unit test was added for this authenticator (existing `tests/test_naive_authenticator.py` was run and still passes unaffected).

## Other Pull Request Checklist

- [x] Code changes pass `pre-commit` (e.g., ruff, mypy, etc.) via `pre-commit run --all-files`.
- [ ] Tests have been added to show the fix is effective or that the new feature works.
- [x] New and existing unit tests pass locally with the changes.
- [x] Docs have been updated and reviewed if relevant.